### PR TITLE
Direct mailer links to alpha subdomain.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,7 +3,7 @@ Webapp::Application.configure do
   config.time_zone = 'Mountain Time (US & Canada)'
 
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = { :host => 'boulderfoodrescue.org' }
+  config.action_mailer.default_url_options = { :host => 'alpha.boulderfoodrescue.org' }
   config.action_mailer.delivery_method = :sendmail
 
   # Code is not reloaded between requests


### PR DESCRIPTION
Password reset mail sends a link erroneously pointing to boulderfoodrescue.org domain instead of the alpha subdomain. Hana says this has been an issue since approximately the time of c59a125. Perhaps see if this fixes the problem?
