### PR TITLE
Change gem source from git:// to https://

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'gmaps4rails', "1.5.6"
 gem "highcharts-rails", "~> 3.0.0"
 
 # gives us pretty data tables
-gem 'jquery-datatables-rails', git: 'git://github.com/rweng/jquery-datatables-rails.git'
+gem 'jquery-datatables-rails', git: 'https://github.com/rweng/jquery-datatables-rails.git'
 
 # pretty select form elements
 #gem 'select2-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/rweng/jquery-datatables-rails.git
+  remote: https://github.com/rweng/jquery-datatables-rails.git
   revision: b8e6b6fa51e0074ea44b4771a68b1817a14023fc
   specs:
     jquery-datatables-rails (3.4.0)


### PR DESCRIPTION
`git://` uses `http` instead of `https`.
Also, this removes the warning when running `bundle install` :)