### PR TITLE
Add `test-unit` to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :test do
   gem 'factory_girl_rails'
   gem 'capybara'
   gem 'rack-test'
+  gem 'test-unit', '~> 3.0'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,7 @@ GEM
     pdf-core (0.6.1)
     pg (0.18.4)
     polyglot (0.3.5)
+    power_assert (0.2.6)
     prawn (2.1.0)
       pdf-core (~> 0.6.1)
       ttfunk (~> 1.4.0)
@@ -267,6 +268,8 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
+    test-unit (3.1.5)
+      power_assert
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
@@ -351,6 +354,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 3.2.6)
   simple_form
+  test-unit (~> 3.0)
   therubyracer
   thin
   twitter


### PR DESCRIPTION
Was getting an error running `bundle exec rails console`.

```
activesupport-3.2.22.2/lib/active_support/dependencies.rb:251:in `require': Please add test-unit gem to your Gemfile: `gem 'test-unit', '~> 3.0'` (cannot load such file -- test/unit/testcase) (LoadError)
```