### PR TITLE
Remove Array#sum monkey-patch

### DIFF
--- a/config/initializers/constant.rb
+++ b/config/initializers/constant.rb
@@ -2,10 +2,6 @@ Webapp::Application.config.DayOfWeek = [["Unknown/varies",nil],["Sunday",0],["Mo
 
 # add some useful functions to the array class
 class Array
-  def sum
-    inject( 0.0 ) { |sum,x| sum ? sum+x : x }
-  end
-
   def mean
     size == 0 ? nil : sum / size
   end


### PR DESCRIPTION
Rails already provides this method, and it takes an optional parameter so these implementations conflict. The only incompatibility could be that this implementation returned a Float instead of an Integer. I looked through the codebase for `sum` and I don't _think_ anything will be affected, but I'm not 100% sure.

@TimothyClayton also had to remove this, I think.

We should eventually move all these monkey patches on Array to a `Calculator` class or something.
