### PR TITLE
Add a rake task to populate the database with sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,24 +87,9 @@ $ exit
 
 Next, copy /config/database.yml.dist to /config/database.yml and make any necessary changes.
 
-If you want to start with an empty schema, you can proceed as usual (rake db:setup, etc.), or you can
-load a database dump from me or elsewhere. If you start with an empty schema, you'll want to start
-by creating a Volunteer user with the admin bit set, and a first region e.g.:
+If you want to start with an empty schema, you can proceed as usual (rake db:setup, etc.), or you can load a database dump from me or elsewhere.
 
-```
-$ rails console
-> r = Region.new
-> r.name = "Somewhere"
-> r.save
->
-> v = Volunteer.new
-> v.email = "jane.doe@gmail.com"
-> v.password = "changeme"
-> v.admin = true
-> v.regions << r
-> v.assigned = true
-> v.save
-```
+You can also populate your local database with sample data by running `rake db:populate`. This will create an admin volunteer with username `volunteer@example.com` and password `changeme`.
 
 ## Running It
 

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -1,0 +1,15 @@
+namespace :db do
+  desc "Fill database with sample data"
+  task :populate => :environment do
+    boulder = Region.where(name: "Boulder").first_or_initialize
+    boulder.save
+
+    admin = Volunteer.where(email: 'volunteer@example.com').first_or_initialize do |v|
+      v.password = 'changeme'
+      v.admin = true
+      v.regions << boulder
+      v.assigned = true
+    end
+    admin.save
+  end
+end


### PR DESCRIPTION
## Overview
Add a rake task to populate the database with sample data. This task can be expanded upon to provide a full set of test data for developers who don't have access to a SQL dump from production.

## Details
- Invoke with `rake db:populate`.
- Will create a new `Region` named "Boulder" and a new `Volunteer` with
email `volunteer@example.com` and password `changeme`.