### PR TITLE
Changing to lp.weight so conv_weight doesn’t break. Poor copy/paste previously.

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -48,7 +48,7 @@ class Log < ActiveRecord::Base
         if record.weight_unit == "kg"
           lp.weight = (lp.weight * (1.0/2.2).to_f).round(2) unless lp.weight.nil?
         elsif record.weight_unit == "st"
-          lp.weight = (conv_weight * (1.0/14.0).to_f).round(2) unless lp.weight.nil?
+          lp.weight = (lp.weight.to_f * (1.0/14.0).to_f).round(2) unless lp.weight.nil?
         end
         lp.save
       }


### PR DESCRIPTION
## Overview
conv_weight was copy pasted from log_part in https://github.com/boulder-food-rescue/food-rescue-robot/commit/9f8c8e6495a3b29f6face03cb2b9a1fb3b799b19 and never defined. So changing to lp.weight.

## Details
conv_weight to lp.weight so its defined for conversion properly. 

