### PR TITLE
Correct typo in registration confirmation message

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -37,7 +37,7 @@ en:
       send_paranoid_instructions: 'If your email address exists in our database, you will receive an email with instructions about how to confirm your account in a few minutes.'
       confirmed: 'Your account was successfully confirmed. You are now signed in.'
     registrations:
-      signed_up: 'Welcome! You have signed up successfully. A region administrator must assign you before you can sign in. You will receive a welcome emaiol after this has been done.'
+      signed_up: 'Welcome! You have signed up successfully. A region administrator must assign you before you can sign in. You will receive a welcome email after this has been done.'
       signed_up_but_unconfirmed: 'A message with a confirmation link has been sent to your email address. Please open the link to activate your account.'
       signed_up_but_inactive: 'You have signed up successfully. However, we could not sign you in because your account is not yet activated. A region administrator must do this before you can sign in. You will receive a welcome email as soon as it has been done.'
       signed_up_but_locked: 'You have signed up successfully. However, we could not sign you in because your account is locked.'


### PR DESCRIPTION
Fixes creative spelling of email in Devise message shown upon successful sign up 