### PR TITLE
Use Region associations over custom scopes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,13 +34,15 @@ class ApplicationController < ActionController::Base
   private
 
   # add in the variables needed by the form partial for schedules and logs
-  def set_vars_for_form region
+  def set_vars_for_form(region)
     @volunteers = Volunteer.all_for_region(region.id).collect{ |v| [v.name,v.id] }
     @donors = Location.donors.where(:region_id=>region.id).collect{ |d| [d.name,d.id] }
     @recipients = Location.recipients.where(:region_id=>region.id).collect{ |r| [r.name,r.id] }
-    @food_types = FoodType.regional(region.id).collect{ |ft| [ft.name,ft.id] }
     @transport_types = TransportType.all.collect{ |tt| [tt.name,tt.id] }
-    @scale_types = ScaleType.regional(region.id).collect{ |st| ["#{st.name} (#{st.weight_unit})",st.id] }
+
+    @food_types = region.food_types.collect { |food_type| [food_type.name, food_type.id] }
+    @scale_types = region.scale_types.collect { |scale_type| ["#{scale_type.name} (#{scale_type.weight_unit})", scale_type.id] }
+
     @regions = Region.all
   end
 

--- a/app/models/food_type.rb
+++ b/app/models/food_type.rb
@@ -9,6 +9,4 @@ class FoodType < ActiveRecord::Base
   has_many :logs, through: :log_parts
 
   default_scope { where(active: true) }
-
-  scope :regional -> (region_id) { where(region_id: region_id) }
 end

--- a/app/models/scale_type.rb
+++ b/app/models/scale_type.rb
@@ -4,8 +4,4 @@ class ScaleType < ActiveRecord::Base
   belongs_to :region
 
   default_scope { where(active:true) }
-
-  def self.regional(region_id)
-    where(:region_id=>region_id)
-  end
 end

--- a/app/views/schedule_chains/_form.html.erb
+++ b/app/views/schedule_chains/_form.html.erb
@@ -145,13 +145,6 @@
       </td>
         <td><%= f.select(:transport_type_id, @transport_types, {}, {class: "form-control"}) %></td>
     </tr>
-    <!--<tr>
-      <td>
-        Food Type(s)</td><td>< FoodType.regional(@schedule.region).each{ |f
-      t| %>
-      <= check_box_tag "schedule[food_type_ids][]", ft.id, @schedule.food_types.include?(ft) %> <= ft.name %>
-    < } %></td>
-    </tr>-->
   </table>
 
   <%= submit_tag %>


### PR DESCRIPTION
## Overview
Some changes to reduce the number of custom scopes in models.

FoodType and ScaleType had `regional` scopes for specifying
a region_id during query. Instead, let's use the framework
and get those records using a ActiveRecord association.