### PR TITLE
Add missing comma in scope definition

### DIFF
--- a/app/models/food_type.rb
+++ b/app/models/food_type.rb
@@ -10,5 +10,5 @@ class FoodType < ActiveRecord::Base
 
   default_scope { where(active: true) }
 
-  scope :regional -> (region_id) { where(region_id: region_id) }
+  scope :regional, -> (region_id) { where(region_id: region_id) }
 end


### PR DESCRIPTION
## Overview
Fixes a syntax error that causes the program to exit when this file is loaded.