### PR TITLE
Needing training scope

### DIFF
--- a/app/models/schedule_chain.rb
+++ b/app/models/schedule_chain.rb
@@ -98,9 +98,7 @@ class ScheduleChain < ActiveRecord::Base
   end
 
   def volunteers_needing_training?
-    somebody_needs_training = false
-    self.volunteers.each { |volunteer| somebody_needs_training |= volunteer.needs_training? }
-    somebody_needs_training
+    volunteers.needing_training.count > 0
   end
 
   def prior_volunteers

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -169,12 +169,14 @@ class Volunteer < ActiveRecord::Base
     end
   end
 
-  # TODO: turn this into SQL
   def self.inactive(region_ids = nil)
-    find_all_by_active(false).
-      keep_if do |v|
-        (region_ids.nil? || (v.region_ids & region_ids).length > 0)
-      end
+    query = where(active: false)
+
+    if region_ids.present?
+      query.joins(:regions).where(regions: { id: region_ids }).group('volunteers.id')
+    else
+      query
+    end
   end
 
   def self.all_for_region(region_id)

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -25,6 +25,8 @@ class Volunteer < ActiveRecord::Base
            conditions: { 'log_volunteers.active' => false },
            class_name: 'Log'
 
+  scope :needing_training, -> { eager_load(:logs).where(logs: { id: nil }) }
+
   attr_accessible :pre_reminders_too, :region_ids, :password,
                   :password_confirmation, :remember_me, :admin_notes, :email,
                   :has_car, :is_disabled, :name, :on_email_list, :phone,

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -159,15 +159,14 @@ class Volunteer < ActiveRecord::Base
 
   ### CLASS METHODS
 
-  # TODO: turn this into SQL
   def self.active(region_ids = nil, ndays = 90)
-    joins(:logs).
-      select('max(logs.when) as last_log_date,volunteers.*').
-      group('volunteers.id').
-      keep_if do |v|
-        (Date.parse(v.last_log_date) > Time.zone.today - ndays) &&
-          (region_ids.nil? || (v.region_ids & region_ids).length > 0)
-      end
+    query = joins(:logs).group('volunteers.id').having('max(logs.when) > ?', Time.zone.today - ndays)
+
+    if region_ids.present?
+      query.joins(:regions).where(regions: { id: region_ids })
+    else
+      query
+    end
   end
 
   # TODO: turn this into SQL

--- a/spec/factories/absences.rb
+++ b/spec/factories/absences.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :absence do
+    start_date { Time.zone.today + 1.day }
+    stop_date { Time.zone.today + 5.days }
+    association :volunteer
+  end
+end

--- a/spec/factories/log_volunteers.rb
+++ b/spec/factories/log_volunteers.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :log_volunteer do
+    association :volunteer
+    association :log
+    active true
+    covering false
+  end
+end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -203,4 +203,23 @@ RSpec.describe Volunteer do
       end
     end
   end
+
+  describe '::needing_training' do
+    subject { described_class.needing_training }
+    let(:log_volunteer) { create(:log_volunteer, volunteer: volunteer) }
+    let(:log) { log_volunteer.log }
+
+    it 'includes volunteers with no complete logs' do
+      expect(subject).to include(volunteer)
+    end
+
+    it 'excludes volunteers with complete logs' do
+      log.complete = true
+      log.why_zero = Log::WhyZero.invert['No Food']
+      log.hours_spent = 1
+      log.save!
+
+      expect(subject).not_to include(volunteer)
+    end
+  end
 end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -2,4 +2,18 @@ require 'rails_helper'
 
 RSpec.describe Volunteer do
   let(:volunteer) { create(:volunteer) }
+
+  describe '#unassigned?' do
+    subject { volunteer }
+
+    it 'returns true if the volunteer has no assignments' do
+      subject.assignments.destroy_all
+      expect(subject.unassigned?).to eq(true)
+    end
+
+    it 'returns false if the volunteer has any assignments' do
+      create(:assignment, volunteer: subject)
+      expect(subject.unassigned?).to eq(false)
+    end
+  end
 end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Volunteer do
+  let(:volunteer) { create(:volunteer) }
+end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -16,4 +16,36 @@ RSpec.describe Volunteer do
       expect(subject.unassigned?).to eq(false)
     end
   end
+
+  describe '#needs_training?' do
+    subject { volunteer }
+
+    context 'when the volunteer has no completed logs' do
+      let(:log_volunteer) { create(:log_volunteer, volunteer: subject) }
+
+      before do
+        log_volunteer.log.complete = false
+        log_volunteer.log.save!
+      end
+
+      it 'returns true' do
+        expect(subject.needs_training?).to eq(true)
+      end
+    end
+
+    context 'when the volunteer has a completed log' do
+      let(:log_volunteer) { create(:log_volunteer, volunteer: subject) }
+
+      before do
+        log_volunteer.log.complete = true
+        log_volunteer.log.hours_spent = 1
+        log_volunteer.log.why_zero = Log::WhyZero.invert["No Food"]
+        log_volunteer.log.save!
+      end
+
+      it 'returns false' do
+        expect(subject.needs_training?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -48,4 +48,69 @@ RSpec.describe Volunteer do
       end
     end
   end
+
+  describe '#current_absences' do
+    subject { volunteer }
+    let(:today) { Date.today }
+
+    it 'includes absences that started before today and end after today' do
+      current_absence = create(:absence, volunteer: subject, start_date: today - 1.day, stop_date: today + 1.day)
+
+      expect(subject.current_absences).to contain_exactly(current_absence)
+    end
+
+    it 'excludes absences for other volunteers' do
+      absence_for_other = create(
+        :absence,
+        start_date: today - 1.day,
+        stop_date: today + 1.day
+      )
+
+      expect(subject.current_absences).not_to include(absence_for_other)
+    end
+
+    it 'excludes absences that start today' do
+      absence_starting_today = create(
+        :absence,
+        volunteer: subject,
+        start_date: today,
+        stop_date: today + 3.days
+      )
+
+      expect(subject.current_absences).not_to include(absence_starting_today)
+    end
+
+    it 'excludes absences that start in the future' do
+      future_absence = create(
+        :absence,
+        volunteer: subject,
+        start_date: today + 1.day,
+        stop_date: today + 3.days
+      )
+
+      expect(subject.current_absences).not_to include(future_absence)
+    end
+
+    it 'excludes absences that stopped in the past' do
+      past_absence = create(
+        :absence,
+        volunteer: subject,
+        start_date: today - 3.days,
+        stop_date: today - 1.day
+      )
+
+      expect(subject.current_absences).not_to include(past_absence)
+    end
+
+    it 'excludes absences that stop today' do
+      absence_stopping_today = create(
+        :absence,
+        volunteer: subject,
+        start_date: today - 3.days,
+        stop_date: today
+      )
+
+      expect(subject.current_absences).not_to include(absence_stopping_today)
+    end
+  end
 end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -169,4 +169,38 @@ RSpec.describe Volunteer do
       end
     end
   end
+
+  describe '::inactive' do
+    let!(:volunteer) { create(:volunteer, active: false) }
+
+    context 'with no parameters' do
+      subject { described_class.inactive }
+
+      it 'includes inactive volunteers' do
+        expect(subject).to include(volunteer)
+      end
+
+      it 'excludes active volunteers' do
+        volunteer.active = true
+        volunteer.save!
+
+        expect(subject).not_to include(volunteer)
+      end
+    end
+
+    context 'with specified region ids' do
+      let(:region) { create(:region) }
+      subject { described_class.inactive([region.id]) }
+
+      it 'includes inactive volunteers assigned to those regions' do
+        create(:assignment, volunteer: volunteer, region: region)
+
+        expect(subject).to include(volunteer)
+      end
+
+      it 'excludes inactive volunteers not assigned to those regions' do
+        expect(subject).not_to include(volunteer)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Overview
Simplifies `ScheduleChain#volunteers_needing_training?` by adding a `Volunteer::needing_training` scope instead of checking each volunteer individually.

## Notes
Just one commit that should be addressed/merged after PR #45.