### PR TITLE
Remove unused association

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,7 +1,6 @@
 class Schedule < ActiveRecord::Base
   include RankedModel
 
-  has_many :volunteers, through: :schedule_volunteers
   has_many :logs
 
   belongs_to :location


### PR DESCRIPTION
## Overview
Calling `volunteers` on a schedule will blow up - removing.