### PR TITLE
Move donors index to separate controller

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -18,10 +18,6 @@ class LocationsController < ApplicationController
     end
   end
 
-  def donors
-    index(Location::LOCATION_TYPES.invert["Donor"],"Donors")
-  end
-
   def hubs
     index(Location::LOCATION_TYPES.invert["Hub"],"Hubs")
   end

--- a/app/controllers/region_admin/donors_controller.rb
+++ b/app/controllers/region_admin/donors_controller.rb
@@ -1,0 +1,38 @@
+module RegionAdmin
+  class DonorsController < ApplicationController
+    before_filter :authenticate_volunteer!
+    before_filter :authorize_region_admin!
+
+    def index
+      @locations = regional_donors
+      @regions   = available_regions
+    end
+
+    private
+
+    def regional_donors
+      if current_volunteer.super_admin?
+        Location.active.donors
+      else
+        Location.active.donors.regional(available_regions.map(&:id))
+      end
+    end
+
+    def available_regions
+      if current_volunteer.super_admin?
+        Region.all
+      else
+        current_volunteer.assignments.collect{ |a| a.admin ? a.region : nil }.compact
+      end
+    end
+
+    def authorize_region_admin!
+      return if region_admin?
+      redirect_to root_url, alert: "Unauthorized"
+    end
+
+    def region_admin?
+      current_volunteer.any_admin?
+    end
+  end
+end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -26,6 +26,8 @@ class Location < ActiveRecord::Base
 
   scope :regional, ->(ids) { where(region_id: ids) }
 
+  scope :active, -> { where(active: true) }
+
   scope :recipients, -> { where(location_type: LOCATION_TYPES.invert['Recipient']) }
   scope :donors,     -> { where(location_type: LOCATION_TYPES.invert['Donor']) }
   scope :hubs,       -> { where(location_type: LOCATION_TYPES.invert['Hub']) }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -94,7 +94,7 @@
             <% end %>
 
             <%= drop_down "Region Admin" do %>
-              <%= menu_item "Donors", donors_locations_path %>
+              <%= menu_item "Donors", region_admin_donors_url %>
               <%= menu_item "Recipients", recipients_locations_path %>
               <% if current_volunteer.main_region.has_sellers? %>
                 <%= menu_item "Sellers", sellers_locations_path %>

--- a/app/views/region_admin/donors/index.html.erb
+++ b/app/views/region_admin/donors/index.html.erb
@@ -1,0 +1,52 @@
+<h2>Donors</h2>
+
+<div style="text-align: right;">
+  <%= form_tag("/locations/new", :method => "get") do %>
+    New Donor Location For <%= select_tag(:region_id, options_for_select(@regions.collect{ |r| [r.name,r.id] })) %>
+    <%= submit_tag("Go") %>
+  <% end %>
+</div>
+
+<% if @locations.empty? %>
+  <p>No locations.</p>
+<% else %>
+  <table id="data_table" class="table table-striped">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Address</th>
+        <th>Link</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @locations.each do |location| %>
+        <tr>
+          <td>
+            <%= link_to location.name.presence || "Unnamed location", location_url(location) %> <%= link_to "(website)", location.website if location.website.present? %>
+          </td>
+          <td>
+            <%= location.address.gsub("\n","<br>").html_safe unless location.address.nil? %>
+          </td>
+          <td>
+            <% if location.receipt_key.present? %>
+              <%= link_to 'Hud', "/locations/hud?id=#{location.id}&key=#{location.receipt_key}" %><br>
+            <% end %>
+            <%= link_to "Edit", edit_location_url(location) %><br>
+            <%= link_to "Delete", location_url(location), :confirm => "Are you sure?", :method => :delete %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<% content_for :scripts do %>
+  <script type="text/javascript">
+    $(function () { 
+      $('#data_table').dataTable({
+        'iDisplayLength' : 50,
+      });
+    });
+  </script>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,7 +75,6 @@ Webapp::Application.routes.draw do
 
   resources :locations do
     collection do
-      get :donors
       get :recipients
       get :hubs
       get :sellers
@@ -118,6 +117,10 @@ Webapp::Application.routes.draw do
   end
 
   resource :waiver, only: [:new, :create]
+
+  namespace :region_admin do
+    resources :donors, only: [:index]
+  end
 
   devise_scope :volunteer do
     authenticated do


### PR DESCRIPTION
## Overview
Move `Location#donors` action out to an independent controller.

Motivations:
- reduce the size and complexity of `LocationsController`
- enforce authorization at controller level
- move to a `region_admin` namespace