### PR TITLE
Fix error introduced in commit a7ad7f1

### DIFF
--- a/app/models/schedule_chain.rb
+++ b/app/models/schedule_chain.rb
@@ -195,7 +195,7 @@ class ScheduleChain < ActiveRecord::Base
 
     return [] if lids.empty?
 
-    schedules.where(location: lids).reject do |x|
+    Schedule.where('schedule_chain_id != ?', id).where(location_id: lids).reject do |x|
       x.schedule_chain.nil?
     end
   end


### PR DESCRIPTION
I misread the implementation of `ScheduleChain#related_shifts` when
cleaning it up (commit a7ad7f1, PR #46).

Loading `/schedule_chains/:id` was blowing up...