### PR TITLE
Replace waiver controller specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,9 +37,10 @@ group :development, :test do
 end
 
 group :test do
-  gem 'rspec-rails', "~> 3.5"
+  gem 'rspec-rails', '~> 3.5'
   gem 'factory_girl_rails'
   gem 'capybara'
+  gem 'poltergeist', '~> 1.12'
   gem 'rack-test'
   gem 'test-unit', '~> 3.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     choice (0.2.0)
     climate_control (0.0.3)
       activesupport (>= 3.0)
+    cliver (0.3.2)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
     cocoon (1.2.9)
@@ -180,6 +181,10 @@ GEM
     orm_adapter (0.5.0)
     pdf-core (0.6.1)
     pg (0.18.4)
+    poltergeist (1.12.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     polyglot (0.3.5)
     power_assert (0.2.6)
     prawn (2.1.0)
@@ -314,6 +319,9 @@ GEM
     unf_ext (0.0.7.2)
     warden (1.2.6)
       rack (>= 1.0)
+    websocket-driver (0.6.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yaml_db (0.3.0)
@@ -348,6 +356,7 @@ DEPENDENCIES
   json
   paperclip!
   pg
+  poltergeist (~> 1.12)
   prawn (~> 2.1.0)
   prawn-table (~> 0.2.2)
   pry-byebug

--- a/spec/controllers/volunteers_controller_spec.rb
+++ b/spec/controllers/volunteers_controller_spec.rb
@@ -364,28 +364,6 @@ RSpec.describe VolunteersController do
     end
   end
 
-  describe 'GET #waiver' do
-    subject { get :waiver }
-
-    before { sign_in volunteer }
-
-    it 'renders the waiver template' do
-      expect(subject).to render_template :waiver
-    end
-  end
-
-  describe 'GET #sign_waiver' do
-    subject do
-      get :sign_waiver, { accept: '1' }
-    end
-
-    before { sign_in volunteer }
-
-    it 'renders the home template' do
-      expect(subject).to render_template :home
-    end
-  end
-
   describe 'GET #knight' do
     subject do
       get :knight, { volunteer_id: volunteer.id }

--- a/spec/factories/volunteers.rb
+++ b/spec/factories/volunteers.rb
@@ -13,6 +13,5 @@ FactoryGirl.define do
         v.save
       end
     end
-
   end
 end

--- a/spec/features/volunteer_waiver_spec.rb
+++ b/spec/features/volunteer_waiver_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe "Volunteer waivers" do
+  
+  let(:region)    { create(:region) }
+  let(:volunteer) { create(:volunteer, regions: [region], assigned: true) }
+
+  feature "A volunteer without a signed waiver" do
+    before do
+      login volunteer
+    end
+
+    it "can sign the waiver" do
+      visit "/waiver/new"
+      expect(page).to have_content("Volunteer Release and Waiver of Liability")
+
+      check "accept"
+      click_on "Sign"
+      expect(page).to have_content("Waiver signed!")
+    end
+  end
+
+  feature "A volunteer with a signed waiver" do
+    before do
+      volunteer.waiver_signed    = true
+      volunteer.waiver_signed_at = Time.zone.now
+      volunteer.save
+
+      login volunteer
+    end
+
+    it "can see the waiver is signed" do
+      visit "/waiver/new"
+      expect(page).to have_content("You signed the waiver")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,14 +1,22 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
+
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
+
 require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'capybara/rails'
+require 'capybara/rspec'
+require 'capybara/poltergeist'
 require 'devise'
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+
+Capybara.javascript_driver = :poltergeist
+Warden.test_mode!
 
 RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -20,7 +28,13 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 
   config.include Devise::TestHelpers, type: :controller
-  config.include Warden::Test::Helpers, type: :request
+
+  config.include Warden::Test::Helpers, type: :feature
+  config.include LoginHelpers,          type: :feature
+
+  config.after(:each) do
+    Warden.test_reset!
+  end
 
   config.include FactoryGirl::Syntax::Methods
 

--- a/spec/support/login_helpers.rb
+++ b/spec/support/login_helpers.rb
@@ -1,0 +1,10 @@
+module LoginHelpers
+  def login(volunteer)
+    visit "/volunteers/sign_in"
+
+    fill_in :volunteer_email,    with: volunteer.email
+    fill_in :volunteer_password, with: "SomePassword"
+
+    click_on "Sign in"
+  end
+end


### PR DESCRIPTION
## Overview
Replace controller specs around Volunteer waivers with integration specs.

- adds integration spec for viewing and signing waivers
- configure capybara with rspec test framework
- adds and configure  poltergeist for JS integration testing

Successor to #58 