### PR TITLE
Add interactor gem and implement first interactor for signing the waiver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,3 +94,5 @@ gem 'addressable'
 #Send email when exception occurs.
 gem 'exception_notification', '~> 3.0.1'
 gem 'exception_notification-rake', '~> 0.0.6'
+
+gem 'interactor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,7 @@ GEM
     http-form_data (1.0.1)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
+    interactor (3.1.0)
     interception (0.5)
     jmespath (1.2.4)
       json_pure (>= 1.8.1)
@@ -351,6 +352,7 @@ DEPENDENCIES
   geocoder
   gmaps4rails (= 1.5.6)
   highcharts-rails (~> 3.0.0)
+  interactor
   jquery-datatables-rails!
   jquery-rails (= 2.1.4)
   json

--- a/app/controllers/waivers_controller.rb
+++ b/app/controllers/waivers_controller.rb
@@ -6,11 +6,12 @@ class WaiversController < ApplicationController
   end
 
   def create
-    if accepted_waiver?
-      sign_waiver
+    if !accepted_waiver?
+      redirect_to new_waiver_url, alert: "Accept the waiver by checking 'Check to sign electronically'"
+    elsif SignWaiver.call(volunteer: current_volunteer, signed_at: Time.zone.now).success?
       redirect_to root_url, notice: 'Waiver signed!'
     else
-      redirect_to new_waiver_url, alert: "Accept the waiver by checking 'Check to sign electronically'"
+      redirect_to new_waiver_url, alert: "There was an error signing the waiver"
     end
   end
 
@@ -18,12 +19,5 @@ class WaiversController < ApplicationController
 
   def accepted_waiver?
     params[:accept].present?
-  end
-
-  def sign_waiver
-    current_volunteer.waiver_signed    = true
-    current_volunteer.waiver_signed_at = Time.zone.now
-
-    current_volunteer.save
   end
 end

--- a/app/interactors/sign_waiver.rb
+++ b/app/interactors/sign_waiver.rb
@@ -1,0 +1,15 @@
+class SignWaiver
+  include Interactor
+
+  delegate :volunteer,
+           :signed_at,
+           :fail!,
+           to: :context
+
+  def call
+    volunteer.waiver_signed    = true
+    volunteer.waiver_signed_at = signed_at
+
+    fail! unless volunteer.save
+  end
+end

--- a/spec/interactors/sign_waiver_spec.rb
+++ b/spec/interactors/sign_waiver_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe SignWaiver do
+  describe '::call' do
+    let(:time) { Time.zone.now.change(sec: 0) }
+
+    let(:volunteer) do
+      create(
+        :volunteer,
+        waiver_signed: false,
+        waiver_signed_at: nil
+      )
+    end
+
+    subject do
+      described_class.call(
+        volunteer: volunteer,
+        signed_at: time
+      )
+    end
+
+    it 'marks the volunteer as having signed the waiver' do
+      expect(subject.success?).to eq(true)
+      expect(volunteer.reload.waiver_signed).to eq(true)
+    end
+
+    it 'saves the time that the volunteer signed the waiver' do
+      expect(subject.success?).to eq(true)
+      expect(volunteer.reload.waiver_signed_at).to eq(time)
+    end
+
+    it 'fails if it cannot save the volunteer' do
+      expect(volunteer).to receive(:save).and_return false
+      expect(subject.success?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Service objects are helpful for cleaning up fat controllers and models (and decoupling the business logic from HTTP). The [`interactor` gem](https://github.com/collectiveidea/interactor) will provide a standard pattern for implementation of these service objects as opposed to using POROs which would be more likely to have varied interfaces.

I chose the "sign waiver" interaction to implement first because it's very simple (and is already covered by tests).
