### PR TITLE
Fix duplicate logs being fetched for each assigned volunteer

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -101,10 +101,14 @@ class Log < ActiveRecord::Base
   end
 
   def self.picked_up_by(volunteer_id, complete=true, limit=nil)
-    if limit.nil?
-      Log.joins(:log_volunteers).where("log_volunteers.volunteer_id = ? AND logs.complete=? AND log_volunteers.active", volunteer_id, complete).order('"logs"."when" DESC')
+    logs = joins(:log_volunteers).
+      where("log_volunteers.volunteer_id = ? AND logs.complete=? AND log_volunteers.active", volunteer_id, complete).
+      order('"logs"."when" DESC')
+
+    if limit.present?
+      logs.limit(limit.to_i)
     else
-      Log.joins(:log_volunteers).where("log_volunteers.volunteer_id = ? AND logs.complete=? AND log_volunteers.active", volunteer_id, complete).order('"logs"."when" DESC').limit(limit.to_i)
+      logs
     end
   end
 

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -2,20 +2,20 @@ class Log < ActiveRecord::Base
   WhyZero = {1 => "No Food", 2 => "Didn't Happen"}
 
   belongs_to :schedule_chain
-  belongs_to :donor, :class_name => "Location", :foreign_key => "donor_id"
+  belongs_to :donor, class_name: "Location", foreign_key: "donor_id"
   belongs_to :scale_type
   belongs_to :transport_type
   belongs_to :region
 
   has_many :log_volunteers
-  has_many :volunteers, :through => :log_volunteers,
-           :conditions=>{"log_volunteers.active"=>true}
-  has_many :inactive_volunteers, :through => :log_volunteers,
-           :conditions=>{"log_volunteers.active"=>false}
+  has_many :volunteers, through: :log_volunteers,
+           conditions: {"log_volunteers.active" => true}
+  has_many :inactive_volunteers, through: :log_volunteers,
+           conditions: {"log_volunteers.active" => false}
   has_many :log_recipients
-  has_many :recipients, :through => :log_recipients
+  has_many :recipients, through: :log_recipients
   has_many :log_parts
-  has_many :food_types, :through => :log_parts
+  has_many :food_types, through: :log_parts
 
   has_and_belongs_to_many :absences
 
@@ -96,7 +96,7 @@ class Log < ActiveRecord::Base
 
   #### CLASS METHODS
 
-  def self.pickup_count region_id
+  def self.pickup_count(region_id)
     Log.where(region_id: region_id, complete: true).count
   end
 
@@ -161,21 +161,21 @@ class Log < ActiveRecord::Base
 
   # Turns a flat array into an array of arrays
   def self.group_by_schedule(logs)
-    ret = []
-    h = {}
-    logs.each{ |log|
+    return_array = []
+    group = {}
+    logs.each { |log|
       if log.schedule_chain.nil?
-        ret << [log]
+        return_array << [log]
       else
-        k = [log.when, log.schedule_chain_id].join(":")
-        if h[k].nil?
-          h[k] = ret.length
-          ret << []
+        key = [log.when, log.schedule_chain_id].join(":")
+        if group[key].nil?
+          group[key] = return_array.length
+          return_array << []
         end
-        ret[h[k]] << log
+        return_array[group[key]] << log
       end
     }
-    ret
+    return_array
   end
 
   def self.to_csv

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -103,7 +103,8 @@ class Log < ActiveRecord::Base
   def self.picked_up_by(volunteer_id, complete=true, limit=nil)
     logs = joins(:log_volunteers).
       where("log_volunteers.volunteer_id = ? AND logs.complete=? AND log_volunteers.active", volunteer_id, complete).
-      order('"logs"."when" DESC')
+      order('"logs"."when" DESC').
+      uniq
 
     if limit.present?
       logs.limit(limit.to_i)


### PR DESCRIPTION
The `Log::picked_up_by` query joins `:log_volunteers` which results in duplicate log objects for each assigned volunteer.

Solution is to use SQL DISTINCT to select distinct log records.