### PR TITLE
Extract Shift class to encapsulate logic around shifts

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -6,15 +6,15 @@ class LogsController < ApplicationController
   before_filter :admin_only, :only => [:today,:tomorrow,:yesterday,:being_covered,:tardy,:receipt,:new,:create,:stats,:export]
 
   def mine_past
-    index(Log.group_by_schedule(Log.past_for(current_volunteer.id)),"My Past Shifts")
+    index(Log.past_for(current_volunteer.id),"My Past Shifts")
   end
 
   def mine_upcoming
-    index(Log.group_by_schedule(Log.upcoming_for(current_volunteer.id)),"My Upcoming Shifts")
+    index(Log.upcoming_for(current_volunteer.id),"My Upcoming Shifts")
   end
 
   def open
-    index(Log.group_by_schedule(Log.needing_coverage(current_volunteer.region_ids)),"Open Shifts")
+    index(Log.needing_coverage(current_volunteer.region_ids),"Open Shifts")
   end
 
   def by_day
@@ -24,30 +24,30 @@ class LogsController < ApplicationController
       n = params[:n].present? ? params[:n].to_i : 0
       d = Time.zone.today+n
     end
-    index(Log.group_by_schedule(Log.where("region_id IN (#{current_volunteer.region_ids.join(",")}) AND \"when\" = '#{d.to_s}'")),"Shifts on #{d.strftime("%A, %B %-d")}")
+    index(Log.where("region_id IN (#{current_volunteer.region_ids.join(",")}) AND \"when\" = '#{d.to_s}'"),"Shifts on #{d.strftime("%A, %B %-d")}")
   end
 
   def last_ten
-    index(Log.group_by_schedule(Log.where("region_id IN (#{current_volunteer.region_ids.join(",")}) AND \"when\" >= '#{(Time.zone.today-10).to_s}'")),"Last 10 Days of Shifts")
+    index(Log.where("region_id IN (#{current_volunteer.region_ids.join(",")}) AND \"when\" >= '#{(Time.zone.today-10).to_s}'"),"Last 10 Days of Shifts")
   end
 
   def being_covered
-    index(Log.group_by_schedule(Log.being_covered(current_volunteer.region_ids)),"Being Covered")
+    index(Log.being_covered(current_volunteer.region_ids),"Being Covered")
   end
 
   def todo
-    index(Log.group_by_schedule(Log.past_for(current_volunteer.id).where("\"when\" < current_date AND NOT complete")),"My To Do Shift Reports")
+    index(Log.past_for(current_volunteer.id).where("\"when\" < current_date AND NOT complete"),"My To Do Shift Reports")
   end
 
   def tardy
-    index(Log.group_by_schedule(Log.where("region_id IN (#{current_volunteer.region_ids.join(",")}) AND \"when\" < current_date AND NOT complete and num_reminders >= 3","Missing Data (>= 3 Reminders)")),"Missing Data (>= 3 Reminders)")
+    index(Log.where("region_id IN (#{current_volunteer.region_ids.join(",")}) AND \"when\" < current_date AND NOT complete and num_reminders >= 3","Missing Data (>= 3 Reminders)"),"Missing Data (>= 3 Reminders)")
   end
 
-  def index(shifts=nil,header="Entire Log")
+  def index(logs=nil,header="Entire Log")
     filter = filter.nil? ? "" : " AND #{filter}"
     @shifts = []
     if current_volunteer.region_ids.length > 0
-      @shifts = shifts.nil? ? Log.group_by_schedule(Log.where("region_id IN (#{current_volunteer.region_ids.join(",")})")) : shifts
+      @shifts = Shift.build_shifts(logs.nil? ? Log.where("region_id IN (#{current_volunteer.region_ids.join(",")})"): logs)
     end
     @header = header
     @regions = Region.all

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -255,8 +255,8 @@ class VolunteersController < ApplicationController
     @open_shift_count = ScheduleChain.open_in_regions(current_volunteer.region_ids).length
 
     #Upcoming pickup list
-    @upcoming_pickups = Log.group_by_schedule(Log.upcoming_for(current_volunteer.id))
-    @sncs_pickups = Log.group_by_schedule(Log.needing_coverage(current_volunteer.region_ids,7,10))
+    @upcoming_pickups = Shift.build_shifts(Log.upcoming_for(current_volunteer.id))
+    @sncs_pickups = Shift.build_shifts(Log.needing_coverage(current_volunteer.region_ids,7,10))
     @sncs_count = Log.needing_coverage(current_volunteer.region_ids,7).length
 
     #To Do Pickup Reports

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -159,25 +159,6 @@ class Log < ActiveRecord::Base
     Log.where("\"when\" >= ?",Time.zone.today).where(:region_id=>region_id_list).order("logs.when").reject{ |l| l.covering_volunteers.empty? }
   end
 
-  # Turns a flat array into an array of arrays
-  def self.group_by_schedule(logs)
-    return_array = []
-    group = {}
-    logs.each { |log|
-      if log.schedule_chain.nil?
-        return_array << [log]
-      else
-        key = [log.when, log.schedule_chain_id].join(":")
-        if group[key].nil?
-          group[key] = return_array.length
-          return_array << []
-        end
-        return_array[group[key]] << log
-      end
-    }
-    return_array
-  end
-
   def self.to_csv
     CSV.generate do |csv|
       csv << ["id","date","item types","item weights","item descriptions","total weight","donor","recipients","volunteers","scale","transport","hours spent","reminders sent","volunteer notes"]

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -46,6 +46,10 @@ class Shift
     logs.map(&:donor).compact
   end
 
+  def recipients
+    logs.flat_map(&:recipients).uniq
+  end
+
   def volunteers_need_training?
     volunteers.any?(&:needs_training?)
   end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -34,6 +34,10 @@ class Shift
     logs.first
   end
 
+  def volunteers
+    logs.flat_map(&:volunteers).uniq
+  end
+
   def volunteers_needed?
     logs.any? { |log| log.volunteers.empty? }
   end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -42,6 +42,14 @@ class Shift
     logs.flat_map(&:volunteers).uniq
   end
 
+  def transport_types
+    logs.map(&:transport_type).compact
+  end
+
+  def food_types_by_log
+    logs.map(&:food_types)
+  end
+
   def donors
     logs.map(&:donor).compact
   end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -33,4 +33,8 @@ class Shift
   def first_log
     logs.first
   end
+
+  def volunteers_needed?
+    logs.any? { |log| log.volunteers.empty? }
+  end
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -34,6 +34,10 @@ class Shift
     logs.first
   end
 
+  def log_ids
+    logs.map(&:id)
+  end
+
   def volunteers
     logs.flat_map(&:volunteers).uniq
   end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -2,6 +2,9 @@ class Shift
   attr_reader :logs
 
   delegate :when,
+           :region,
+           :absences,
+           :schedule_chain,
            to: :first_log
 
   def self.build_shifts(logs)

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -38,6 +38,10 @@ class Shift
     logs.flat_map(&:volunteers).uniq
   end
 
+  def volunteers_need_training?
+    volunteers.any?(&:needs_training?)
+  end
+
   def volunteers_needed?
     logs.any? { |log| log.volunteers.empty? }
   end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -23,4 +23,8 @@ class Shift
   def initialize(logs)
     @logs = logs
   end
+
+  def first_log
+    logs.first
+  end
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -1,6 +1,9 @@
 class Shift
   attr_reader :logs
 
+  delegate :when,
+           to: :first_log
+
   def self.build_shifts(logs)
     shifts = []
     group = {}

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -1,0 +1,26 @@
+class Shift
+  attr_reader :logs
+
+  def self.build_shifts(logs)
+    shifts = []
+    group = {}
+    logs.each { |log|
+      if log.schedule_chain.nil?
+        shifts << [log]
+      else
+        key = [log.when, log.schedule_chain_id].join(":")
+        if group[key].nil?
+          group[key] = shifts.length
+          shifts << []
+        end
+        shifts[group[key]] << log
+      end
+    }
+
+    shifts.map { |shift_logs| new(shift_logs) }
+  end
+
+  def initialize(logs)
+    @logs = logs
+  end
+end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -50,6 +50,14 @@ class Shift
     logs.flat_map(&:recipients).uniq
   end
 
+  def summed_weight
+    logs.sum(&:summed_weight)
+  end
+
+  def complete?
+    logs.all?(&:complete)
+  end
+
   def volunteers_need_training?
     volunteers.any?(&:needs_training?)
   end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -42,6 +42,10 @@ class Shift
     logs.flat_map(&:volunteers).uniq
   end
 
+  def donors
+    logs.map(&:donor).compact
+  end
+
   def volunteers_need_training?
     volunteers.any?(&:needs_training?)
   end

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -112,7 +112,7 @@
                 <% shift.donors.each do |donor| %> <%= link_to donor.name, donor %><br> <% end %>
               </td>
               <td>
-                <% shift.logs.collect{ |shift| shift.recipients }.flatten.uniq.each do |recip| %> <%= link_to recip.name, recip %> <br> <% end %>
+                <% shift.recipients.each do |recip| %> <%= link_to recip.name, recip %> <br> <% end %>
               </td>
 
               <% unless current_page?(controller: "logs", action: "open") %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -66,7 +66,7 @@
           %>
             <tr <% unless row_bgcolor.nil? %>style="background: <%= row_bgcolor %>;"<% end %>>
               <td>
-                <%= first_shift.when.strftime("%Y-%m-%d") %>
+                <%= shift.when.strftime("%Y-%m-%d") %>
               </td>
               <td>
                 <% unless first_shift.schedule_chain.nil? %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -109,7 +109,7 @@
               </td>
 
               <td>
-                <% shift.logs.each do |shift| %> <%= (shift.donor != nil) ? (link_to shift.donor.name, shift.donor) : "" %><br> <% end %>
+                <% shift.donors.each do |donor| %> <%= link_to donor.name, donor %><br> <% end %>
               </td>
               <td>
                 <% shift.logs.collect{ |shift| shift.recipients }.flatten.uniq.each do |recip| %> <%= link_to recip.name, recip %> <br> <% end %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -120,10 +120,12 @@
                   <%= shift.complete? ? shift.summed_weight.round : "?" %> lbs.
                 </td>
                 <td>
-                  <% shift.logs.collect{ |shift| shift.transport_type }.compact.each{ |transport_type| %> <%= transport_type.name %><br> <% } %>
+                  <% shift.transport_types.each{ |transport_type| %> <%= transport_type.name %><br> <% } %>
                 </td>
                 <td>
-                  <%= shift.logs.collect{ |shift| shift.food_types.collect{ |food_type| food_type.name }.join(", ") }.join("<br>").html_safe %>
+                  <% shift.food_types_by_log.each do |types| %>
+                    <div><%= types.map(&:name).join(", ") %></div>
+                  <% end %>
                 </td>
               <% end %>
 

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -82,7 +82,7 @@
               </td>
               <td>
                 <% if shift.volunteers_needed? %>
-                  <%= link_to take_log_path(shift.first_log, ids: shift.logs.collect{ |shift| shift.id }), class: 'btn btn-primary take' do %>
+                  <%= link_to take_log_path(shift.first_log, ids: shift.log_ids), class: 'btn btn-primary take' do %>
                     <i class="fa fa-hand-rock-o"></i>
                     Cover Shift
                   <% end %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -79,11 +79,11 @@
                 <% end %>
               </td>
               <td>
-                <%= readable_time_until first_shift %>
+                <%= readable_time_until shift.first_log %>
               </td>
               <td>
                 <% if shift.logs.any?{ |shift| shift.volunteers.empty? } %>
-                  <%= link_to take_log_path(first_shift, ids: shift.logs.collect{ |shift| shift.id }), class: 'btn btn-primary take' do %>
+                  <%= link_to take_log_path(shift.first_log, ids: shift.logs.collect{ |shift| shift.id }), class: 'btn btn-primary take' do %>
                     <i class="fa fa-hand-rock-o"></i>
                     Cover Shift
                   <% end %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -54,13 +54,13 @@
         </thead>
         <tbody>
           <%
-            @shifts.each do |shift_group|
-              first_shift = shift_group[0]
+            @shifts.each do |shift|
+              first_shift = shift.logs[0]
               row_bgcolor = nil
 
-              if shift_group.any?{ |shift_group| shift_group.volunteers.empty? } and not current_page?(controller: "logs", action: "open")
+              if shift.logs.any?{ |shift_group| shift_group.volunteers.empty? } and not current_page?(controller: "logs", action: "open")
                 row_bgcolor = "pink"
-              elsif shift_group.any? { |shift_group| shift_group.volunteers.any?{ |volunteer| volunteer.needs_training? } }
+              elsif shift.logs.any? { |shift_group| shift_group.volunteers.any?{ |volunteer| volunteer.needs_training? } }
                 row_bgcolor = "lightgreen"
               end
           %>
@@ -82,16 +82,16 @@
                 <%= readable_time_until first_shift %>
               </td>
               <td>
-                <% if shift_group.any?{ |shift| shift.volunteers.empty? } %>
-                  <%= link_to take_log_path(first_shift, ids: shift_group.collect{ |shift| shift.id }), class: 'btn btn-primary take' do %>
+                <% if shift.logs.any?{ |shift| shift.volunteers.empty? } %>
+                  <%= link_to take_log_path(first_shift, ids: shift.logs.collect{ |shift| shift.id }), class: 'btn btn-primary take' do %>
                     <i class="fa fa-hand-rock-o"></i>
                     Cover Shift
                   <% end %>
                 <% else %>
-                  <% shift_group.collect{ |shift| shift.volunteers }.flatten.uniq.each do |volunteer| %>
+                  <% shift.logs.collect{ |shift| shift.volunteers }.flatten.uniq.each do |volunteer| %>
                     <%= link_to volunteer.name, volunteer %><br />
                   <% end %>
-                  <%= render 'take_or_leave', logs: shift_group %>
+                  <%= render 'take_or_leave', logs: shift.logs %>
                 <% end %>
 
                 <% unless first_shift.absences.empty? %>
@@ -110,33 +110,33 @@
               </td>
 
               <td>
-                <% shift_group.each do |shift| %> <%= (shift.donor != nil) ? (link_to shift.donor.name, shift.donor) : "" %><br> <% end %>
+                <% shift.logs.each do |shift| %> <%= (shift.donor != nil) ? (link_to shift.donor.name, shift.donor) : "" %><br> <% end %>
               </td>
               <td>
-                <% shift_group.collect{ |shift| shift.recipients }.flatten.uniq.each do |recip| %> <%= link_to recip.name, recip %> <br> <% end %>
+                <% shift.logs.collect{ |shift| shift.recipients }.flatten.uniq.each do |recip| %> <%= link_to recip.name, recip %> <br> <% end %>
               </td>
 
               <% unless current_page?(controller: "logs", action: "open") %>
                 <td>
-                  <%= shift_group.all?{ |shift| shift.complete } ? shift_group.collect{ |shift| shift.summed_weight }.sum.round : "?" %> lbs.
+                  <%= shift.logs.all?{ |shift| shift.complete } ? shift.logs.collect{ |shift| shift.summed_weight }.sum.round : "?" %> lbs.
                 </td>
                 <td>
-                  <% shift_group.collect{ |shift| shift.transport_type }.compact.each{ |transport_type| %> <%= transport_type.name %><br> <% } %>
+                  <% shift.logs.collect{ |shift| shift.transport_type }.compact.each{ |transport_type| %> <%= transport_type.name %><br> <% } %>
                 </td>
                 <td>
-                  <%= shift_group.collect{ |shift| shift.food_types.collect{ |food_type| food_type.name }.join(", ") }.join("<br>").html_safe %>
+                  <%= shift.logs.collect{ |shift| shift.food_types.collect{ |food_type| food_type.name }.join(", ") }.join("<br>").html_safe %>
                 </td>
               <% end %>
 
               <td style="font-size: 10pt;">
-                <% shift_group.each{ |shift|
+                <% shift.logs.each{ |shift|
                   next if shift.notes.nil?
                 %>
                   <%= word_wrap(shift.notes, line_width: 20).gsub("\n","<br>").html_safe %><hr>
                 <% } %>
                 <% if current_volunteer.any_admin?(first_shift.region) %>
                   <td>
-                    <% shift_group.each{ |shift_group| %>
+                    <% shift.logs.each{ |shift_group| %>
                       <%= link_to "edit", edit_log_path(shift_group), class: 'btn btn-primary' %>
                       <%= link_to "delete", shift_group, class: 'btn btn-danger', confirm: "Are you sure?", method: :delete %>
                     <% } %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -59,7 +59,7 @@
 
               if shift.volunteers_needed? and not current_page?(controller: "logs", action: "open")
                 row_bgcolor = "pink"
-              elsif shift.logs.any? { |shift_group| shift_group.volunteers.any?{ |volunteer| volunteer.needs_training? } }
+              elsif shift.volunteers_need_training?
                 row_bgcolor = "lightgreen"
               end
           %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -117,7 +117,7 @@
 
               <% unless current_page?(controller: "logs", action: "open") %>
                 <td>
-                  <%= shift.logs.all?{ |shift| shift.complete } ? shift.logs.collect{ |shift| shift.summed_weight }.sum.round : "?" %> lbs.
+                  <%= shift.complete? ? shift.summed_weight.round : "?" %> lbs.
                 </td>
                 <td>
                   <% shift.logs.collect{ |shift| shift.transport_type }.compact.each{ |transport_type| %> <%= transport_type.name %><br> <% } %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -55,7 +55,6 @@
         <tbody>
           <%
             @shifts.each do |shift|
-              first_shift = shift.logs[0]
               row_bgcolor = nil
 
               if shift.logs.any?{ |shift_group| shift_group.volunteers.empty? } and not current_page?(controller: "logs", action: "open")
@@ -69,8 +68,8 @@
                 <%= shift.when.strftime("%Y-%m-%d") %>
               </td>
               <td>
-                <% unless first_shift.schedule_chain.nil? %>
-                  <%= link_to schedule_chain_path(first_shift.schedule_chain.id), class: 'btn btn-info info' do %>
+                <% unless shift.schedule_chain.nil? %>
+                  <%= link_to schedule_chain_path(shift.schedule_chain.id), class: 'btn btn-info info' do %>
                     <i class="fa fa-info-circle"></i>
                     Info
                   <% end %>
@@ -94,11 +93,11 @@
                   <%= render 'take_or_leave', logs: shift.logs %>
                 <% end %>
 
-                <% unless first_shift.absences.empty? %>
+                <% unless shift.absences.empty? %>
                   <small>
                     <br>
                       (normally:
-                        <% first_shift.absences.each do |absence| %>
+                        <% shift.absences.each do |absence| %>
                           <% if absence.volunteer.present? %>
                             <%= absence.volunteer.name %>,
                           <% else %>
@@ -134,7 +133,7 @@
                 %>
                   <%= word_wrap(shift.notes, line_width: 20).gsub("\n","<br>").html_safe %><hr>
                 <% } %>
-                <% if current_volunteer.any_admin?(first_shift.region) %>
+                <% if current_volunteer.any_admin?(shift.region) %>
                   <td>
                     <% shift.logs.each{ |shift_group| %>
                       <%= link_to "edit", edit_log_path(shift_group), class: 'btn btn-primary' %>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -57,7 +57,7 @@
             @shifts.each do |shift|
               row_bgcolor = nil
 
-              if shift.logs.any?{ |shift_group| shift_group.volunteers.empty? } and not current_page?(controller: "logs", action: "open")
+              if shift.volunteers_needed? and not current_page?(controller: "logs", action: "open")
                 row_bgcolor = "pink"
               elsif shift.logs.any? { |shift_group| shift_group.volunteers.any?{ |volunteer| volunteer.needs_training? } }
                 row_bgcolor = "lightgreen"
@@ -81,7 +81,7 @@
                 <%= readable_time_until shift.first_log %>
               </td>
               <td>
-                <% if shift.logs.any?{ |shift| shift.volunteers.empty? } %>
+                <% if shift.volunteers_needed? %>
                   <%= link_to take_log_path(shift.first_log, ids: shift.logs.collect{ |shift| shift.id }), class: 'btn btn-primary take' do %>
                     <i class="fa fa-hand-rock-o"></i>
                     Cover Shift

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -87,7 +87,7 @@
                     Cover Shift
                   <% end %>
                 <% else %>
-                  <% shift.logs.collect{ |shift| shift.volunteers }.flatten.uniq.each do |volunteer| %>
+                  <% shift.volunteers.each do |volunteer| %>
                     <%= link_to volunteer.name, volunteer %><br />
                   <% end %>
                   <%= render 'take_or_leave', logs: shift.logs %>

--- a/app/views/volunteers/home.html.erb
+++ b/app/views/volunteers/home.html.erb
@@ -48,7 +48,7 @@
               <% } %>
             </td>
             <td>
-              <%= readable_time_until first_pickup %>
+              <%= readable_time_until shift.first_log %>
             </td>
             <td>
               <% unless first_pickup.schedule_chain.nil? %>
@@ -141,10 +141,10 @@
                 <% } %>
               </td>
               <td>
-                <%= readable_time_until first_pickup %>
+                <%= readable_time_until shift.first_log %>
               </td>
               <td>
-                <button class="btn btn-primary take" onclick="window.location='<%= take_log_path(first_pickup.id,:ids => shift.logs.collect{ |p| p.id }) %>';">
+                <button class="btn btn-primary take" onclick="window.location='<%= take_log_path(shift.first_log,:ids => shift.logs.collect{ |p| p.id }) %>';">
                   <i class="fa fa-hand-rock-o"></i>
                   Take
                 </button>

--- a/app/views/volunteers/home.html.erb
+++ b/app/views/volunteers/home.html.erb
@@ -31,11 +31,11 @@
           <th>Date</th>
           <th>Link</th>
         </tr>
-        <% @upcoming_pickups.each do |pickup_group|
-           first_pickup = pickup_group[0] %>
+        <% @upcoming_pickups.each do |shift|
+           first_pickup = shift.logs[0] %>
            <tr class="bordered">
             <td>
-              <% pickup_group.each{ |pickup| %>
+              <% shift.logs.each{ |pickup| %>
                 <%= link_to pickup.donor.try(:name), pickup.donor if pickup.donor.present? %> -&gt;
                   <% pickup.recipients.each do |recip| %>
                     <%= link_to recip.try(:name), recip if recip.present? %>
@@ -124,13 +124,13 @@
         </thead>
         <tbody>
           <% n = 0
-          @sncs_pickups.each do |pickup_group|
-            next if pickup_group.all? {|x| x.donor.nil? or x.recipients.empty? }
-            first_pickup = pickup_group[0]
+          @sncs_pickups.each do |shift|
+            next if shift.logs.all? {|x| x.donor.nil? or x.recipients.empty? }
+            first_pickup = shift.logs[0]
             %>
             <tr class="bordered">
               <td>
-                <% pickup_group.each{ |pickup| %>
+                <% shift.logs.each{ |pickup| %>
                 <% next if pickup.donor.nil? or pickup.recipients.empty? %>
                 <%= link_to pickup.donor.name, pickup.donor %> -&gt; <% pickup.recipients.each do |recip| %> <%=link_to recip.name, recip %> <% end %>
                 <% unless pickup.food_types.empty? %>
@@ -144,7 +144,7 @@
                 <%= readable_time_until first_pickup %>
               </td>
               <td>
-                <button class="btn btn-primary take" onclick="window.location='<%= take_log_path(first_pickup.id,:ids => pickup_group.collect{ |p| p.id }) %>';">
+                <button class="btn btn-primary take" onclick="window.location='<%= take_log_path(first_pickup.id,:ids => shift.logs.collect{ |p| p.id }) %>';">
                   <i class="fa fa-hand-rock-o"></i>
                   Take
                 </button>

--- a/app/views/volunteers/home.html.erb
+++ b/app/views/volunteers/home.html.erb
@@ -31,8 +31,7 @@
           <th>Date</th>
           <th>Link</th>
         </tr>
-        <% @upcoming_pickups.each do |shift|
-           first_pickup = shift.logs[0] %>
+        <% @upcoming_pickups.each do |shift| %>
            <tr class="bordered">
             <td>
               <% shift.logs.each{ |pickup| %>
@@ -51,8 +50,8 @@
               <%= readable_time_until shift.first_log %>
             </td>
             <td>
-              <% unless first_pickup.schedule_chain.nil? %>
-                <button class="btn btn-info info" onclick="window.location='/schedule_chains/<%= first_pickup.schedule_chain.id %>';">
+              <% unless shift.schedule_chain.nil? %>
+                <button class="btn btn-info info" onclick="window.location='/schedule_chains/<%= shift.schedule_chain.id %>';">
                   <i class="fa fa-info-circle"></i>
                   Info
                 </button>
@@ -126,7 +125,6 @@
           <% n = 0
           @sncs_pickups.each do |shift|
             next if shift.logs.all? {|x| x.donor.nil? or x.recipients.empty? }
-            first_pickup = shift.logs[0]
             %>
             <tr class="bordered">
               <td>
@@ -150,8 +148,8 @@
                 </button>
               </td>
               <td>
-                <% if first_pickup.schedule_chain.present? %>
-                  <button class="btn btn-info info" onclick="window.location='/schedule_chains/<%= first_pickup.schedule_chain.id %>';">
+                <% if shift.schedule_chain.present? %>
+                  <button class="btn btn-info info" onclick="window.location='/schedule_chains/<%= shift.schedule_chain.id %>';">
                     <i class="fa fa-info-circle"></i>
                     Info
                   </button>

--- a/app/views/volunteers/home.html.erb
+++ b/app/views/volunteers/home.html.erb
@@ -142,7 +142,7 @@
                 <%= readable_time_until shift.first_log %>
               </td>
               <td>
-                <button class="btn btn-primary take" onclick="window.location='<%= take_log_path(shift.first_log,:ids => shift.logs.collect{ |p| p.id }) %>';">
+                <button class="btn btn-primary take" onclick="window.location='<%= take_log_path(shift.first_log,:ids => shift.log_ids) %>';">
                   <i class="fa fa-hand-rock-o"></i>
                   Take
                 </button>


### PR DESCRIPTION
In a number of places, the app appears to be implicitly hinting at the concept of a "shift": a collection of logs belonging to the same schedule chain and occurring on the same date.

This PR adds a `Shift` model that is not backed by a SQL table, but encapsulates functionality related to a "shift".

I think `Shift` could eventually be a first-class Rails model, with its own SQL table, but there's a good deal of code that'd have to be refactored to get there. I think this PR is a good first step in that direction.