### PR TITLE
Fix export as super admin

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -397,14 +397,14 @@ class LogsController < ApplicationController
   end
 
   def export
-    @start_date = Date.new(params[:start_date][:year].to_i,params[:start_date][:month].to_i,params[:start_date][:day].to_i)
-    @stop_date = Date.new(params[:stop_date][:year].to_i,params[:stop_date][:month].to_i,params[:stop_date][:day].to_i)
-    @regions = current_volunteer.admin_regions(true)
-    @logs = Log.where("logs.when >= ? AND logs.when <= ? AND complete AND region_id IN (#{@regions.collect{ |r| r.id }.join(",")})",@start_date,@stop_date)
+    start_date = Date.new(params[:start_date][:year].to_i,params[:start_date][:month].to_i,params[:start_date][:day].to_i)
+    stop_date = Date.new(params[:stop_date][:year].to_i,params[:stop_date][:month].to_i,params[:stop_date][:day].to_i)
+    regions = current_volunteer.admin_regions(true)
+    logs = Log.where("logs.when >= ? AND logs.when <= ? AND complete AND region_id IN (#{regions.collect{ |r| r.id }.join(",")})",start_date,stop_date)
     respond_to do |format|
       format.html
       format.csv do
-        send_data @logs.to_csv
+        send_data logs.to_csv
       end
     end
   end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -400,7 +400,12 @@ class LogsController < ApplicationController
     start_date = Date.new(params[:start_date][:year].to_i,params[:start_date][:month].to_i,params[:start_date][:day].to_i)
     stop_date = Date.new(params[:stop_date][:year].to_i,params[:stop_date][:month].to_i,params[:stop_date][:day].to_i)
     regions = current_volunteer.admin_regions(true)
-    logs = Log.where("logs.when >= ? AND logs.when <= ? AND complete AND region_id IN (#{regions.collect{ |r| r.id }.join(",")})",start_date,stop_date)
+
+    logs = Log.where("logs.when >= ? AND logs.when <= ?", start_date, stop_date).where(
+      complete: true,
+      region_id: regions.map(&:id)
+    )
+
     respond_to do |format|
       format.html
       format.csv do

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -399,7 +399,7 @@ class LogsController < ApplicationController
   def export
     start_date = Date.new(params[:start_date][:year].to_i,params[:start_date][:month].to_i,params[:start_date][:day].to_i)
     stop_date = Date.new(params[:stop_date][:year].to_i,params[:stop_date][:month].to_i,params[:stop_date][:day].to_i)
-    regions = current_volunteer.admin_regions(true)
+    regions = current_volunteer.admin_regions
 
     logs = Log.where("logs.when >= ? AND logs.when <= ?", start_date, stop_date).where(
       complete: true,


### PR DESCRIPTION
This fixes the error just sent out via email:

```
An ActiveRecord::StatementInvalid occurred in logs#export:

PG::SyntaxError: ERROR:  syntax error at or near ")"
LINE 1: … logs.when <= ‘2017-01-08’ AND complete AND region_id IN ())

^
: SELECT “logs".* FROM "logs” WHERE (logs.when >= ‘2017-01-04’ AND logs.when <= ‘2017-01-08’ AND complete AND region_id IN ())
```

Super admins have no `Assignment`s where `admin` is `true`. So `super_admin.admin_regions(true)` returns an empty array.

This PR changes `LogsController#export` to use the non-strict version of the function so that all regions are retrieved.
