### PR TITLE
Only save associated log parts if they already exist in the database

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -53,7 +53,7 @@ class Log < ActiveRecord::Base
         elsif record.weight_unit == "st"
           lp.weight = (lp.weight.to_f * (1.0/14.0).to_f).round(2) unless lp.weight.nil?
         end
-        lp.save
+        lp.save unless lp.new_record?
       }
       record.weight_unit = "lb"
     end


### PR DESCRIPTION
Fixes #74.

There was an issue where duplicate `log_volunteer` records were created when saving a `Log` with associated volunteers and `log_parts` created in memory. The problem only occurred in regions with exactly one scale type because the newly created logs are assigned that scale type.

We don't want to save the associated records individually as they depend on the `Log` record. We just set the attributes on them and let ActiveRecord save them itself.

---

I'd recommend we also remove all the duplicate records and add a uniqueness constraint on the DB. This SQL should delete all duplicate `log_volunteer` records, keeping the most recently created one:

```sql
WITH t AS (
  SELECT id, rank() OVER (PARTITION BY volunteer_id, log_id ORDER BY created_at DESC) AS rank
  FROM log_volunteers
)
DELETE FROM log_volunteers WHERE id IN (SELECT id FROM t WHERE rank > 1);
```