### PR TITLE
Ef/fix duplicate log volunteers

### DIFF
--- a/db/migrate/20170126022713_prevent_duplicate_log_volunteers.rb
+++ b/db/migrate/20170126022713_prevent_duplicate_log_volunteers.rb
@@ -1,10 +1,15 @@
 require File.join(__dir__, '../../lib/de_dup_log_volunteers.rb')
 class PreventDuplicateLogVolunteers < ActiveRecord::Migration
+  INDEX_NAME = 'index_log_volunteers_on_log_id_and_volunteer_id'
   def up
     DeDupLogVolunteers.de_duplicate
-    add_index :log_volunteers, [:log_id, :volunteer_id], unique: true
+    ActiveRecord::Base.connection.execute <<-SQL
+      CREATE UNIQUE INDEX "#{INDEX_NAME}"
+      ON "log_volunteers" ("log_id", "volunteer_id")
+      WHERE active is true
+    SQL
   end
   def down
-    remove_index :log_volunteers, column: [:log_id, :volunteer_id]
+    remove_index :log_volunteers, name: INDEX_NAME
   end
 end

--- a/db/migrate/20170126022713_prevent_duplicate_log_volunteers.rb
+++ b/db/migrate/20170126022713_prevent_duplicate_log_volunteers.rb
@@ -1,7 +1,10 @@
+require File.join(__dir__, '../../lib/de_dup_log_volunteers.rb')
 class PreventDuplicateLogVolunteers < ActiveRecord::Migration
-  # This adds a uniqueness constraint to table log_volunteers
-  # Be sure to run de-duplication first: `rake db:cleanup:log_volunteers`
-  def change
+  def up
+    DeDupLogVolunteers.de_duplicate
     add_index :log_volunteers, [:log_id, :volunteer_id], unique: true
+  end
+  def down
+    remove_index :log_volunteers, column: [:log_id, :volunteer_id]
   end
 end

--- a/db/migrate/20170126022713_prevent_duplicate_log_volunteers.rb
+++ b/db/migrate/20170126022713_prevent_duplicate_log_volunteers.rb
@@ -1,0 +1,7 @@
+class PreventDuplicateLogVolunteers < ActiveRecord::Migration
+  # This adds a uniqueness constraint to table log_volunteers
+  # Be sure to run de-duplication first: `rake db:cleanup:log_volunteers`
+  def change
+    add_index :log_volunteers, [:log_id, :volunteer_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150623180213) do
+ActiveRecord::Schema.define(:version => 20170126022713) do
 
   create_table "absences", :force => true do |t|
     t.integer "volunteer_id"
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(:version => 20150623180213) do
     t.boolean  "covering"
   end
 
+  add_index "log_volunteers", ["log_id", "volunteer_id"], :name => "index_log_volunteers_on_log_id_and_volunteer_id", :unique => true
   add_index "log_volunteers", ["log_id"], :name => "index_log_volunteers_on_log_id"
   add_index "log_volunteers", ["volunteer_id"], :name => "index_log_volunteers_on_volunteer_id"
 

--- a/lib/de_dup_log_volunteers.rb
+++ b/lib/de_dup_log_volunteers.rb
@@ -1,0 +1,11 @@
+class DeDupLogVolunteers
+  def self.de_duplicate
+    too_many_records = LogVolunteer.select([:id, :log_id, :volunteer_id]).all
+    # that is a "make it work" solution. if it takes too long,
+    # do the work to run a SQL query
+    dups = too_many_records.group_by { |r| [r.log_id, r.volunteer_id] }
+    dups.each do |group, records|
+      records[1..-1].each(&:destroy)
+    end
+  end
+end

--- a/lib/de_dup_log_volunteers.rb
+++ b/lib/de_dup_log_volunteers.rb
@@ -1,16 +1,20 @@
 class DeDupLogVolunteers
   def self.de_duplicate
-    dup_pairs = LogVolunteer.select(
-      ['count(1) as ct', :log_id, :volunteer_id]
-    ).having('1 < ct').group(:log_id, :volunteer_id)
-    dup_pairs.each do |dp|
-      dups = LogVolunteer.where(log_id: dp.log_id, volunteer_id: dp.volunteer_id)
-      covering = dups.inject(false) { |covering, d| covering || d.covering }
-      active = dups.inject(false) { |active, d| active || d.active }
-      dups[1..-1].each(&:destroy)
-      dups[0].covering = covering
-      dups[0].active = active
-      dups[0].save!
-    end
+    ActiveRecord::Base.connection.execute <<-SQL
+WITH t AS (
+  SELECT
+    id,
+    volunteer_id,
+    log_id,
+    rank() OVER (
+      PARTITION BY volunteer_id, log_id ORDER BY created_at DESC
+    ) AS rank
+  FROM log_volunteers
+  WHERE active = true
+)
+UPDATE log_volunteers
+SET active = false
+WHERE id IN (SELECT id FROM t WHERE rank > 1);
+    SQL
   end
 end

--- a/spec/controllers/volunteers_controller_spec.rb
+++ b/spec/controllers/volunteers_controller_spec.rb
@@ -1,9 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe VolunteersController do
+  before :context do
+    Volunteer.destroy_all
+  end
   let(:volunteer) { create :volunteer_with_assignment }
   let(:admin) { create :volunteer_with_assignment, admin: true }
-  let(:resource) { create :volunteer }
+  let(:resource) { volunteer }
 
   it_behaves_like 'an authenticated indexable resource'
   it_behaves_like 'an authenticated showable resource'

--- a/spec/lib/de_dup_log_volunteers_spec.rb
+++ b/spec/lib/de_dup_log_volunteers_spec.rb
@@ -2,22 +2,88 @@ require 'rails_helper'
 require 'de_dup_log_volunteers'
 
 RSpec.describe DeDupLogVolunteers do
+  before :context do
+    Log.destroy_all
+    @log = FactoryGirl.create(:log)
+    Volunteer.destroy_all
+    @volunteer = FactoryGirl.create(:volunteer)
+  end
+  before :example do
+    LogVolunteer.destroy_all
+    @log2 = FactoryGirl.create(:log)
+    LogVolunteer.create!(log_id: @log2.id, volunteer_id: @volunteer.id)
+    begin
+      dup = LogVolunteer.create!(log_id: @log2.id, volunteer_id: @volunteer.id)
+      dup.destroy
+    rescue ActiveRecord::StatementInvalid
+      skip # duplicates are no longer allowed
+    end
+  end
   it 'removes duplicates' do
-    log = FactoryGirl.create(:log)
-    volunteer = FactoryGirl.create(:volunteer)
-    LogVolunteer.create!(log_id: log.id, volunteer_id: volunteer.id)
-    LogVolunteer.create!(log_id: log.id, volunteer_id: volunteer.id)
-    LogVolunteer.create!(log_id: log.id, volunteer_id: volunteer.id)
-    log2 = FactoryGirl.create(:log)
-    LogVolunteer.create!(log_id: log2.id, volunteer_id: volunteer.id)
-    expect(LogVolunteer.count).to eq 4
+    LogVolunteer.create!(log_id: @log.id, volunteer_id: @volunteer.id)
+    LogVolunteer.create!(log_id: @log.id, volunteer_id: @volunteer.id)
+    LogVolunteer.create!(log_id: @log.id, volunteer_id: @volunteer.id)
+    LogVolunteer.create!(log_id: @log.id, volunteer_id: @volunteer.id)
+    expect(LogVolunteer.count).to eq 5
 
     DeDupLogVolunteers.de_duplicate
 
     expect(LogVolunteer.count).to eq 2
-    log1_r = LogVolunteer.where(log_id: log.id)
+    log1_r = LogVolunteer.where(log_id: @log.id)
     expect(log1_r.count).to eq 1
-    log2_r = LogVolunteer.where(log_id: log2.id)
+    log2_r = LogVolunteer.where(log_id: @log2.id)
     expect(log2_r.count).to eq 1
+  end
+  it 'captures covering true' do
+    LogVolunteer.create!(log_id: @log.id, volunteer_id: @volunteer.id,
+      active: true, covering: false)
+    LogVolunteer.create!(log_id: @log.id, volunteer_id: @volunteer.id,
+      active: false, covering: false)
+    LogVolunteer.create!(log_id: @log.id, volunteer_id: @volunteer.id,
+      active: true, covering: true)
+
+    DeDupLogVolunteers.de_duplicate
+
+    log1_r = LogVolunteer.where(log_id: @log.id)
+    expect(log1_r.count).to eq 1
+    expect(log1_r.first.covering).to be true
+  end
+  it 'captures covering false' do
+    LogVolunteer.create!(log_id: @log.id, volunteer_id: @volunteer.id,
+      active: true, covering: false)
+    LogVolunteer.create!(log_id: @log.id, volunteer_id: @volunteer.id,
+      active: false, covering: false)
+
+    DeDupLogVolunteers.de_duplicate
+
+    log1_r = LogVolunteer.where(log_id: @log.id)
+    expect(log1_r.count).to eq 1
+    expect(log1_r.first.covering).to be false
+  end
+  it 'captures active true' do
+    LogVolunteer.create!(log_id: @log.id, volunteer_id: @volunteer.id,
+      active: false, covering: true)
+    LogVolunteer.create!(log_id: @log.id, volunteer_id: @volunteer.id,
+      active: false, covering: false)
+    LogVolunteer.create!(log_id: @log.id, volunteer_id: @volunteer.id,
+      active: true, covering: true)
+
+    DeDupLogVolunteers.de_duplicate
+
+    log1_r = LogVolunteer.where(log_id: @log.id)
+    expect(log1_r.count).to eq 1
+    expect(log1_r.first.active).to be true
+  end
+  it 'captures active false' do
+    LogVolunteer.create!(log_id: @log.id, volunteer_id: @volunteer.id,
+      active: false, covering: true)
+    LogVolunteer.create!(log_id: @log.id, volunteer_id: @volunteer.id,
+      active: false, covering: false)
+
+    DeDupLogVolunteers.de_duplicate
+
+    log1_r = LogVolunteer.where(log_id: @log.id)
+    expect(log1_r.count).to eq 1
+    expect(log1_r.first.active).to be false
   end
 end

--- a/spec/lib/de_dup_log_volunteers_spec.rb
+++ b/spec/lib/de_dup_log_volunteers_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe DeDupLogVolunteers do
       dup = LogVolunteer.create!(log_id: @log2.id, volunteer_id: @volunteer.id)
       dup.destroy
     rescue ActiveRecord::StatementInvalid
-      skip # duplicates are no longer allowed
+      skip "duplicate log_volunteers are now prevented"
     end
   end
   it 'removes duplicates' do

--- a/spec/lib/de_dup_log_volunteers_spec.rb
+++ b/spec/lib/de_dup_log_volunteers_spec.rb
@@ -11,12 +11,14 @@ RSpec.describe DeDupLogVolunteers do
   end
   before :example do
     LogVolunteer.destroy_all
-    LogVolunteer.create!(log_id: @log2.id, volunteer_id: @volunteer.id)
+    LogVolunteer.create!(log_id: @log2.id, volunteer_id: @volunteer.id,
+      active: true)
     begin
-      dup = LogVolunteer.create!(log_id: @log2.id, volunteer_id: @volunteer.id)
+      dup = LogVolunteer.create!(log_id: @log2.id, volunteer_id: @volunteer.id,
+        active: true)
       dup.destroy
     rescue ActiveRecord::StatementInvalid
-      skip "duplicate log_volunteers are now prevented"
+      skip "duplicate log_volunteers with active = true are now prevented"
     end
     3.times do
       LogVolunteer.create(log_id: @log.id, volunteer_id: @volunteer.id,

--- a/spec/lib/de_dup_log_volunteers_spec.rb
+++ b/spec/lib/de_dup_log_volunteers_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+require 'de_dup_log_volunteers'
+
+RSpec.describe DeDupLogVolunteers do
+  it 'removes duplicates' do
+    log = FactoryGirl.create(:log)
+    volunteer = FactoryGirl.create(:volunteer)
+    LogVolunteer.create!(log_id: log.id, volunteer_id: volunteer.id)
+    LogVolunteer.create!(log_id: log.id, volunteer_id: volunteer.id)
+    LogVolunteer.create!(log_id: log.id, volunteer_id: volunteer.id)
+    log2 = FactoryGirl.create(:log)
+    LogVolunteer.create!(log_id: log2.id, volunteer_id: volunteer.id)
+    expect(LogVolunteer.count).to eq 4
+
+    DeDupLogVolunteers.de_duplicate
+
+    expect(LogVolunteer.count).to eq 2
+    log1_r = LogVolunteer.where(log_id: log.id)
+    expect(log1_r.count).to eq 1
+    log2_r = LogVolunteer.where(log_id: log2.id)
+    expect(log2_r.count).to eq 1
+  end
+end

--- a/spec/models/log_volunteer_spec.rb
+++ b/spec/models/log_volunteer_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe LogVolunteer do
+  it 'prevents duplicate records' do
+    log = FactoryGirl.create(:log)
+    volunteer = FactoryGirl.create(:volunteer)
+    expect do
+      lv = LogVolunteer.create!(log_id: log.id, volunteer_id: volunteer.id)
+      lv = LogVolunteer.create!(log_id: log.id, volunteer_id: volunteer.id)
+    end.to raise_error(ActiveRecord::StatementInvalid)
+  end
+end


### PR DESCRIPTION
## Overview
This is to remove duplicates from the log_volunteer_table and prevent adding new ones

## Details
We wrote and tested a class, `DeDupLogVolunteers` that contains a class method to do the clean-up.

We wrote and tested a migration that adds a unique index to the table.  The migration uses the `DeDupLogVolunteers` class to clear duplicates before adding the index.


