### PR TITLE
Added translation for signed_up_but_not_assigned.

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -45,6 +45,7 @@ en:
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and click on the confirm link to finalize confirming your new email address."
       destroyed: 'Bye! Your account was successfully cancelled. We hope to see you again soon.'
       signed_up_but_not_approved: 'You have signed up successfully but your account has not been approved by your administrator yet.'
+      signed_up_but_not_assigned: 'Welcome! You have signed up successfully. A region administrator must assign you before you can sign in. You will receive a welcome email after this has been done.'
     unlocks:
       send_instructions: 'You will receive an email with instructions about how to unlock your account in a few minutes.'
       unlocked: 'Your account has been unlocked successfully. Please sign in to continue.'


### PR DESCRIPTION
## Overview
Addresses Issue #79 

## Details
The devise .yml file contains a translation for `signed_up` that is intended to be presented when a user signs up for the site. But devise is looking for `signed_up_but_not_assigned`, and when a user signs up, they receive the message "translation missing" as documented in Issue #79. This PR provides the missing translation. The text is identical to the existing text for `signed_up`.
