### PR TITLE
Remove LogPart#scale_weight method

### DIFF
--- a/app/models/log_part.rb
+++ b/app/models/log_part.rb
@@ -2,17 +2,4 @@ class LogPart < ActiveRecord::Base
   belongs_to :log
   belongs_to :food_type
   attr_accessible :required, :weight, :count, :description, :food_type_id, :log_id
-
-  # weight in db is always lbs, so convert to what the user expects to see (in the units of the scale)
-  def scale_weight
-    display_unit = self.log.scale_type.weight_unit
-    if display_unit == 'kg'
-      self.weight*2.2
-    elsif display_unit == 'st'
-      self.weight*14
-    else
-      self.weight
-    end
-  end
-
 end


### PR DESCRIPTION
## Overview
This PR addresses issue #86. LogPart#scale_weight is not used in the code and appears to be faulty on its face. Best course of action seems to be to delete the method.
