### PR TITLE
[cleanup] Remove broken Region associations

### DIFF
--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -6,8 +6,6 @@ class Region < ActiveRecord::Base
   has_many :schedule_chains
   has_many :locations
   has_many :logs
-  has_many :donors
-  has_many :recipients
 
   scope :all_admin, ->(volunteer) { where(id: volunteer.admin_region_ids) }
 


### PR DESCRIPTION
Both of these associations fail with errors:

`NameError: uninitialized constant Region::Donor` and `NameError: uninitialized constant Region::Recipient`

If they were being used anywhere, it would fail, so I feel comfortable just removing them.
