### PR TITLE
Remove trailing commas

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -136,12 +136,6 @@ Style/Alias:
   Exclude:
     - 'app/controllers/application_controller.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-Style/AlignArray:
-  Exclude:
-    - 'db/seeds.rb'
-
 # Offense count: 59
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedHashRocketStyle, SupportedHashRocketStyles, EnforcedColonStyle, SupportedColonStyles, EnforcedLastArgumentHashStyle, SupportedLastArgumentHashStyles.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -78,8 +78,8 @@ volunteer.save!
 assignment = Assignment.new({
   'admin'=>false
 })
-assignment.volunteer_id = volunteer.id,
-assignment.region_id = region.id,
+assignment.volunteer_id = volunteer.id
+assignment.region_id = region.id
 assignment.save!
 
 super_admin = Volunteer.create({
@@ -136,6 +136,6 @@ region_assignment = Assignment.new({
   'admin'=>true
 })
 
-assignment.volunteer_id = region_admin.id,
-assignment.region_id = region.id,
+assignment.volunteer_id = region_admin.id
+assignment.region_id = region.id
 assignment.save!


### PR DESCRIPTION
## Overview
I came across some trailing commas in `seeds.rb` that cause some unintended behavior.

## Details
These trailing commas result in an array being assigned to `assignment.volunteer_id` rather than separate values being assigned to `assignment.volunteer_id` and `assignment.region_id`.

## Notes

```
> a = 1,
> b = 2,
=> [1, 2]
> a
=> [1, 2]
> b
=> 2
```
