### PR TITLE
Add rubocop to circle ci build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  pre:
+    - bundle exec rubocop


### PR DESCRIPTION
## Overview
Make sure we don't merge any code that breaks rubocop styles.