### PR TITLE
Fix flaky ability test

### DIFF
--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Ability do
       let(:region) { create(:region) }
       let(:volunteer_log) { create(:log, region: region) }
       let(:region_log) { create(:log, region: region) }
-      let(:other_log) { create(:log) }
+      let(:other_log) { create(:log, region: create(:region)) }
 
       before do
         create(:assignment, volunteer: volunteer, region: region)


### PR DESCRIPTION
The test has failed in the following circle ci builds:

- https://circleci.com/gh/boulder-food-rescue/food-rescue-robot/164
- https://circleci.com/gh/boulder-food-rescue/food-rescue-robot/180
- https://circleci.com/gh/boulder-food-rescue/food-rescue-robot/185

My hypothesis is that this flakiness is caused by the behavior of the logs factory when a region is not explicitly provided. The factory [picks a random region if at least 5 exist](https://github.com/boulder-food-rescue/food-rescue-robot/blob/ef/fix_flaky_ability_test/spec/factories/logs.rb#L5). That could occassionally pick the region that the volunteer is actually assigned to, making the test fail.

By assigning an explicitly different region to the log, my hope is that the test will no longer fail.