### PR TITLE
Address `number.times.map` pattern violation

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -65,16 +65,6 @@ Performance/StringReplacement:
   Exclude:
     - 'app/models/location.rb'
 
-# Offense count: 7
-# Cop supports --auto-correct.
-Performance/TimesMap:
-  Exclude:
-    - 'lib/sample_data/region_data/admin_data.rb'
-    - 'lib/sample_data/region_data/donor_data.rb'
-    - 'lib/sample_data/region_data/recipient_data.rb'
-    - 'lib/sample_data/region_data/schedule_chain_data.rb'
-    - 'lib/sample_data/region_data/volunteer_data.rb'
-
 # Offense count: 1
 Style/AccessorMethodName:
   Exclude:

--- a/lib/sample_data/region_data/admin_data.rb
+++ b/lib/sample_data/region_data/admin_data.rb
@@ -17,7 +17,7 @@ class SampleData
                   :number
 
       def admins
-        @admins ||= number.times.map do |i|
+        @admins ||= Array.new(number) do |i|
           Volunteer.new(
             email: "admin-#{region.name.parameterize}#{i + 1 > 1 ? "-#{i + 1}" : ''}@example.com",
             name: Faker::Name.name,

--- a/lib/sample_data/region_data/donor_data.rb
+++ b/lib/sample_data/region_data/donor_data.rb
@@ -18,7 +18,7 @@ class SampleData
                   :number
 
       def donors
-        @donors ||= number.times.map do
+        @donors ||= Array.new(number) do
           Location.new(
             region_id: region.id,
             location_type: Location::LOCATION_TYPES.invert["Donor"],

--- a/lib/sample_data/region_data/recipient_data.rb
+++ b/lib/sample_data/region_data/recipient_data.rb
@@ -18,7 +18,7 @@ class SampleData
                   :number
 
       def recipients
-        @recipients ||= number.times.map do
+        @recipients ||= Array.new(number) do
           Location.new(
             region_id: region.id,
             location_type: Location::LOCATION_TYPES.invert["Recipient"],

--- a/lib/sample_data/region_data/schedule_chain_data.rb
+++ b/lib/sample_data/region_data/schedule_chain_data.rb
@@ -16,7 +16,7 @@ class SampleData
                   :number
 
       def schedule_chains
-        @schedule_chains ||= number.times.map do
+        @schedule_chains ||= Array.new(number) do
           times = random_start_stop_times
           frequency = %w(weekly one-time).sample
 
@@ -58,7 +58,7 @@ class SampleData
         sched_locations << active_record_random_from(region.locations.donors)
 
         # Select some random locations (donors or recipients)
-        rand(4).times.map do
+        Array.new(rand(4)) do
           sched_locations << active_record_random_from(region.locations.where('locations.id NOT IN (?)', sched_locations))
         end
 
@@ -76,7 +76,7 @@ class SampleData
       def random_volunteers
         volunteers = []
 
-        rand(3).times.map do
+        Array.new(rand(3)) do
           volunteers << active_record_random_from(
             volunteers.empty? ?
               region.volunteers :

--- a/lib/sample_data/region_data/volunteer_data.rb
+++ b/lib/sample_data/region_data/volunteer_data.rb
@@ -17,7 +17,7 @@ class SampleData
                   :number
 
       def volunteers
-        @volunteers ||= number.times.map do
+        @volunteers ||= Array.new(number) do
           name = "#{Faker::Name.first_name} #{Faker::Name.last_name}"
 
           Volunteer.new(


### PR DESCRIPTION
## Overview

Provides more idiomatic `Array.new(number)` pattern instead of `number.times.map`. 
