### PR TITLE
Add feature test for viewing shifts needing cov.

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -256,8 +256,8 @@ class VolunteersController < ApplicationController
 
     #Upcoming pickup list
     @upcoming_pickups = Shift.build_shifts(Log.upcoming_for(current_volunteer.id))
-    @sncs_pickups = Shift.build_shifts(Log.needing_coverage(current_volunteer.region_ids, 7, 10))
-    @sncs_count = Log.needing_coverage(current_volunteer.region_ids, 7).length
+    @shifts_needing_cov = Shift.build_shifts(Log.needing_coverage(current_volunteer.region_ids, 7, 10))
+    @total_shifts_needing_cov= Log.needing_coverage(current_volunteer.region_ids, 7).length
 
     #To Do Pickup Reports
     @to_do_reports = Log.picked_up_by(current_volunteer.id, false)

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -140,18 +140,16 @@ class Log < ActiveRecord::Base
   end
 
   def self.needing_coverage(region_id_list=nil, days_away=nil, limit=nil)
-    unless region_id_list.nil?
-      if days_away.nil?
-        Log.where('"when" >= ?', Time.zone.today).where(:region_id=>region_id_list).order('logs.when').limit(limit).reject{ |l| l.covered? }
-      else
+    if region_id_list
+      if days_away
         Log.where('"when" >= ? AND "when" <= ?', Time.zone.today, Time.zone.today+days_away).where(:region_id=>region_id_list).order('logs.when').limit(limit).reject{ |l| l.covered? }
-      end
-    else
-      if days_away.nil?
-        Log.where('"when" >= ?', Time.zone.today).order('logs.when').limit(limit).reject{ |l| l.covered? }
       else
-        Log.where('"when" >= ? AND "when" <= ?', Time.zone.today, Time.zone.today+days_away).order('logs.when').limit(limit).reject{ |l| l.covered? }
+        Log.where('"when" >= ?', Time.zone.today).where(:region_id=>region_id_list).order('logs.when').limit(limit).reject{ |l| l.covered? }
       end
+    elsif days_away
+      Log.where('"when" >= ? AND "when" <= ?', Time.zone.today, Time.zone.today+days_away).order('logs.when').limit(limit).reject{ |l| l.covered? }
+    else
+      Log.where('"when" >= ?', Time.zone.today).order('logs.when').limit(limit).reject{ |l| l.covered? }
     end
   end
 

--- a/app/views/volunteers/home.html.erb
+++ b/app/views/volunteers/home.html.erb
@@ -1,7 +1,7 @@
-<% if @sncs_count > 0 %>
+<% if @total_shifts_needing_cov > 0 %>
   <div class="alert fade in alert-danger" onclick="window.location='<%= open_logs_path %>';" style="cursor:pointer;">
     <i class="fa fa-exclamation-triangle"></i>
-    <%= @sncs_count %> Shifts Need Covering Soon: <%= link_to "Pick one up here.", open_logs_path %>
+    <%= @total_shifts_needing_cov %> Shifts Need Covering Soon: <%= link_to "Pick one up here.", open_logs_path %>
   </div>
 <% end %>
 
@@ -111,7 +111,7 @@
 <div class="row bordered-bottom">
   <div class="col-sm-6">
     <h2>Shifts Needing Covering!</h2>
-    <% if @sncs_pickups.length > 0 %>
+    <% if @shifts_needing_cov.length > 0 %>
       <table class="table table-striped">
         <thead>
           <tr>
@@ -123,17 +123,17 @@
         </thead>
         <tbody>
           <% n = 0
-          @sncs_pickups.each do |shift|
-            next if shift.logs.all? {|x| x.donor.nil? or x.recipients.empty? }
+          @shifts_needing_cov.each do |shift|
+            next if shift.logs.all? {|log| log.donor.nil? or log.recipients.empty? }
             %>
             <tr class="bordered">
               <td>
-                <% shift.logs.each{ |pickup| %>
-                <% next if pickup.donor.nil? or pickup.recipients.empty? %>
-                <%= link_to pickup.donor.name, pickup.donor %> -&gt; <% pickup.recipients.each do |recip| %> <%=link_to recip.name, recip %> <% end %>
-                <% unless pickup.food_types.empty? %>
+                <% shift.logs.each{ |log| %>
+                <% next if log.donor.nil? or log.recipients.empty? %>
+                <%= link_to log.donor.name, log.donor %> -&gt; <% log.recipients.each do |recip| %> <%=link_to recip.name, recip %> <% end %>
+                <% unless log.food_types.empty? %>
                 <br />
-                <em>(<%= pickup.food_types.collect{ |ft| ft.name }.join(",") %>)</em>
+                <em>(<%= log.food_types.collect{ |type| type.name }.join(",") %>)</em>
                 <% end %>
                 <br />
                 <% } %>

--- a/spec/features/shifts_needing_coverage_spec.rb
+++ b/spec/features/shifts_needing_coverage_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'Shifts needing coverage' do
+  let!(:region)    { create(:region) }
+  let!(:volunteer) { create(:volunteer, :not_waived, regions: [region], assigned: true) }
+  let!(:log)       { create(:log, region_id: volunteer.region_ids[0], when: Time.zone.today + 1.day) }
+
+  feature 'When a volunteer visits the homepage' do
+    before(:each) do
+      login volunteer
+      allow_any_instance_of(ApplicationController).to receive(:current_volunteer).and_return(volunteer)
+      allow(volunteer).to receive(:waiver_signed?).and_return(true)
+    end
+
+    it 'they see the shifts in their region that need covering' do
+      visit root_path
+
+      within page.find('h2', text: 'Shifts Needing Covering').find('+table') do
+        expect(page).to have_link(log.donor.name, href: location_path(log.donor))
+        expect(page).to have_button('Take')
+        log.food_types.each do |type|
+          expect(page).to have_content(type.name)
+        end
+      end
+    end
+
+    it 'and they dont see the shifts out of their region that need covering' do
+      other_region_log = create(:log, when: Time.zone.today + 2.days)
+
+      visit root_path
+
+      within page.find('h2', text: 'Shifts Needing Covering').find('+table') do
+        expect(page).to_not have_link(other_region_log.donor.name, href: location_path(other_region_log.donor))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Overview

In response to #94 , this adds feature tests for volunteers viewing shifts that still need coverage. I also change the relevant instance variables set in the `volunteers#home` action and the nested conditionals in `Log.needing_coverage` for improved readability.

@rylanb 