### PR TITLE
Updating ruby code climate threshold to 30.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,8 +10,9 @@ engines:
     enabled: true
     config:
       languages:
-      - ruby
-      - javascript
+        ruby:
+          mass_threshold: 30
+        javascript:
   eslint:
     enabled: false
   fixme:


### PR DESCRIPTION
Single quotes in development.rb

## Overview
Code climate is reporting a LOT of code duplicaton, so trying to up that threshold to avoid.

## Details
Docs: https://docs.codeclimate.com/docs/duplication

