### PR TITLE
Fixing the shift coverage spec blinking failure. 

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -257,16 +257,16 @@ class VolunteersController < ApplicationController
     #Upcoming pickup list
     @upcoming_pickups = Shift.build_shifts(Log.upcoming_for(current_volunteer.id))
     @shifts_needing_cov = Shift.build_shifts(Log.needing_coverage(current_volunteer.region_ids, 7, 10))
-    @total_shifts_needing_cov= Log.needing_coverage(current_volunteer.region_ids, 7).length
+    @total_shifts_needing_cov = Log.needing_coverage(current_volunteer.region_ids, 7).length
 
     #To Do Pickup Reports
     @to_do_reports = Log.picked_up_by(current_volunteer.id, false)
 
     @by_month = {}
-    Log.picked_up_by(current_volunteer.id).each{ |l|
-      yrmo = l.when.strftime('%Y-%m')
-      @by_month[yrmo] = 0.0 if @by_month[yrmo].nil?
-      @by_month[yrmo] += l.summed_weight unless l.summed_weight.nil?
+    Log.picked_up_by(current_volunteer.id).each{ |log|
+      year_month = log.when.strftime('%Y-%m')
+      @by_month[year_month] = 0.0 if @by_month[year_month].nil?
+      @by_month[year_month] += log.summed_weight unless log.summed_weight.nil?
     }
 
     @volunteer_stats_presenter = VolunteerStatsPresenter.new(current_volunteer)

--- a/app/views/volunteers/home.html.erb
+++ b/app/views/volunteers/home.html.erb
@@ -122,27 +122,32 @@
           </tr>
         </thead>
         <tbody>
-          <% n = 0
-          @shifts_needing_cov.each do |shift|
-            next if shift.logs.all? {|log| log.donor.nil? or log.recipients.empty? }
-            %>
+          <% @shifts_needing_cov.each do |shift| %>
+
+            <% next if shift.logs.all? { |log| log.donor.nil? || log.recipients.empty? } %>
+
             <tr class="bordered">
               <td>
-                <% shift.logs.each{ |log| %>
-                <% next if log.donor.nil? or log.recipients.empty? %>
-                <%= link_to log.donor.name, log.donor %> -&gt; <% log.recipients.each do |recip| %> <%=link_to recip.name, recip %> <% end %>
-                <% unless log.food_types.empty? %>
-                <br />
-                <em>(<%= log.food_types.collect{ |type| type.name }.join(",") %>)</em>
+                <% shift.logs.each do |log| %>
+                  <% next if log.donor.nil? || log.recipients.empty? %>
+
+                  <%= link_to log.donor.name, log.donor %> -&gt;
+                  <% log.recipients.each do |recip| %>
+                    <%=link_to recip.name, recip %>
+                  <% end %>
+
+                  <% unless log.food_types.empty? %>
+                    <br />
+                    <em>(<%= log.food_types.collect{ |type| type.name }.join(",") %>)</em>
+                  <% end %>
+                  <br />
                 <% end %>
-                <br />
-                <% } %>
               </td>
               <td>
                 <%= readable_time_until shift.first_log %>
               </td>
               <td>
-                <button class="btn btn-primary take" onclick="window.location='<%= take_log_path(shift.first_log,:ids => shift.log_ids) %>';">
+                <button class="btn btn-primary take" onclick="window.location='<%= take_log_path(shift.first_log, ids: shift.log_ids) %>';">
                   <i class="fa fa-hand-rock-o"></i>
                   Take
                 </button>

--- a/spec/factories/logs.rb
+++ b/spec/factories/logs.rb
@@ -7,10 +7,10 @@ FactoryGirl.define do
     donor { Location.donors.count >= 5 ? Location.donors.sort_by{ rand }.first : create(:donor) }
 
     after(:create) do |d|
-      rand(3).times{
+      rand(1..3).times{
         d.recipients << (Location.recipients.count >= 5 ? Location.recipients.sort_by{ rand }.first : create(:recipient))
       }
-      rand(3).times{
+      rand(1..3).times{
         d.log_parts << create(:log_part)
       }
       d.scale_type = (ScaleType.all.count >= 5 ? ScaleType.all.sort_by{ rand }.first : create(:scale_type, region: d.region))

--- a/spec/features/region_admin/food_types/create_spec.rb
+++ b/spec/features/region_admin/food_types/create_spec.rb
@@ -1,12 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe "Region Admin Food Types" do
+RSpec.describe 'Region Admin Food Types' do
+  feature 'Creating a new food type' do
+    let(:boulder) { create(:region, name: 'Boulder') }
+    let(:denver)  { create(:region, name: 'Denver') }
 
-  feature "Creating a new food type" do
-    let(:boulder) { create(:region, name: "Boulder") }
-    let(:denver)  { create(:region, name: "Denver") }
-
-    context "as a region admin" do
+    context 'as a region admin' do
       let(:volunteer) { create(:volunteer, regions: [], assigned: true) }
 
       before do
@@ -16,24 +15,24 @@ RSpec.describe "Region Admin Food Types" do
         login volunteer
       end
 
-      context "on success" do
-        it "creates a new food type" do
-          visit "/region_admin/food_types/new"
+      context 'on success' do
+        it 'creates a new food type' do
+          visit '/region_admin/food_types/new'
 
-          select "Boulder", from: :food_type_region_id
-          fill_in :food_type_name, with: "Canned"
-          click_on "Create Food type"
+          select 'Boulder', from: :food_type_region_id
+          fill_in :food_type_name, with: 'Canned'
+          click_on 'Create Food type'
 
-          expect(page).to have_content("Created successfully.")
+          expect(page).to have_content('Created successfully.')
         end
       end
 
-      context "on failure" do
+      context 'on failure' do
         # Can't fail thru the UI. RF 1-18-17
       end
     end
 
-    context "as a super admin" do
+    context 'as a super admin' do
       let(:volunteer) { create(:volunteer, regions: [], assigned: true, admin: true) }
 
       before do
@@ -42,36 +41,36 @@ RSpec.describe "Region Admin Food Types" do
         login volunteer
       end
 
-      it "creates a new food type" do
-        visit "/region_admin/food_types/new"
+      it 'creates a new food type' do
+        visit '/region_admin/food_types/new'
 
-        select "Boulder", from: :food_type_region_id
-        fill_in :food_type_name, with: "Canned"
-        click_on "Create Food type"
+        select 'Boulder', from: :food_type_region_id
+        fill_in :food_type_name, with: 'Canned'
+        click_on 'Create Food type'
 
-        expect(page).to have_content("Created successfully.")
+        expect(page).to have_content('Created successfully.')
       end
     end
 
-    context "as a visitor" do
-      it "redirects to sign in" do
-        visit "/region_admin/food_types/new"
+    context 'as a visitor' do
+      it 'redirects to sign in' do
+        visit '/region_admin/food_types/new'
 
-        expect(page.current_path).to eq("/volunteers/sign_in")
+        expect(page.current_path).to eq('/volunteers/sign_in')
       end
     end
 
-    context "as a volunteer" do
+    context 'as a volunteer' do
       let(:volunteer) { create(:volunteer, regions: [boulder], assigned: true) }
 
       before do
         login volunteer
       end
 
-      it "redirects to home" do
-        visit "/region_admin/food_types/new"
+      it 'redirects to home' do
+        visit '/region_admin/food_types/new'
 
-        expect(page.current_path).to eq("/")
+        expect(page.current_path).to eq('/')
       end
     end
   end

--- a/spec/features/region_admin/food_types/delete_spec.rb
+++ b/spec/features/region_admin/food_types/delete_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Region Admin Food Types" do
-
-  feature "Deleting a food type" do
+RSpec.describe 'Region Admin Food Types' do
+  feature 'Deleting a food type' do
     let!(:boulder) { create(:region) }
     let!(:denver)  { create(:region) }
 
@@ -10,11 +9,11 @@ RSpec.describe "Region Admin Food Types" do
       create(
         :food_type,
         region: boulder,
-        name:   "Canned"
+        name:   'Canned'
       )
     end
 
-    context "as a region admin" do
+    context 'as a region admin' do
       let(:volunteer) { create(:volunteer, regions: [], assigned: true) }
 
       before do
@@ -24,18 +23,18 @@ RSpec.describe "Region Admin Food Types" do
         login volunteer
       end
 
-      it "deletes the food type" do
-        visit "/region_admin/food_types"
+      it 'deletes the food type' do
+        visit '/region_admin/food_types'
 
-        within("table") do
-          click_link "Delete"
+        within('table') do
+          click_link 'Delete'
         end
 
-        expect(page).to have_content("Deleted successfully.")
+        expect(page).to have_content('Deleted successfully.')
       end
     end
 
-    context "as a super admin" do
+    context 'as a super admin' do
       let(:volunteer) { create(:volunteer, regions: [], assigned: true, admin: true) }
 
       before do
@@ -44,36 +43,36 @@ RSpec.describe "Region Admin Food Types" do
         login volunteer
       end
 
-      it "deletes the food type" do
-        visit "/region_admin/food_types"
+      it 'deletes the food type' do
+        visit '/region_admin/food_types'
 
-        within("table") do
-          click_link "Delete"
+        within('table') do
+          click_link 'Delete'
         end
 
-        expect(page).to have_content("Deleted successfully.")
+        expect(page).to have_content('Deleted successfully.')
       end
     end
 
-    context "as a visitor" do
-      it "redirects to sign in" do
-        visit "/region_admin/food_types/new"
+    context 'as a visitor' do
+      it 'redirects to sign in' do
+        visit '/region_admin/food_types/new'
 
-        expect(page.current_path).to eq("/volunteers/sign_in")
+        expect(page.current_path).to eq('/volunteers/sign_in')
       end
     end
 
-    context "as a volunteer" do
+    context 'as a volunteer' do
       let(:volunteer) { create(:volunteer, regions: [boulder], assigned: true) }
 
       before do
         login volunteer
       end
 
-      it "redirects to home" do
-        visit "/region_admin/food_types/new"
+      it 'redirects to home' do
+        visit '/region_admin/food_types/new'
 
-        expect(page.current_path).to eq("/")
+        expect(page.current_path).to eq('/')
       end
     end
   end

--- a/spec/features/region_admin/food_types/index_spec.rb
+++ b/spec/features/region_admin/food_types/index_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Region Admin Food Types" do
-
-  feature "Viewing the list of food types" do
+RSpec.describe 'Region Admin Food Types' do
+  feature 'Viewing the list of food types' do
     let(:boulder) { create(:region) }
     let(:denver)  { create(:region) }
 
@@ -10,7 +9,7 @@ RSpec.describe "Region Admin Food Types" do
       create(
         :food_type,
         region: boulder,
-        name:   "Boulder food type"
+        name:   'Boulder food type'
       )
     end
 
@@ -18,11 +17,11 @@ RSpec.describe "Region Admin Food Types" do
       create(
         :food_type,
         region: denver,
-        name:   "Denver food type"
+        name:   'Denver food type'
       )
     end
 
-    context "as a region admin" do
+    context 'as a region admin' do
       let(:volunteer) { create(:volunteer, regions: [], assigned: true) }
 
       before do
@@ -32,20 +31,20 @@ RSpec.describe "Region Admin Food Types" do
         login volunteer
       end
 
-      it "can see the list of food types in administrated regions" do
-        visit "/region_admin/food_types"
+      it 'can see the list of food types in administrated regions' do
+        visit '/region_admin/food_types'
 
-        expect(page).to have_content("Boulder food type")
+        expect(page).to have_content('Boulder food type')
       end
 
-      it "cannot see food types from unadministered regions" do
-        visit "/region_admin/food_types"
+      it 'cannot see food types from unadministered regions' do
+        visit '/region_admin/food_types'
 
-        expect(page).to_not have_content("Denver food type")
+        expect(page).to_not have_content('Denver food type')
       end
     end
 
-    context "as a super admin" do
+    context 'as a super admin' do
       let(:volunteer) { create(:volunteer, regions: [], assigned: true, admin: true) }
 
       before do
@@ -54,33 +53,33 @@ RSpec.describe "Region Admin Food Types" do
         login volunteer
       end
 
-      it "can see the list of food types in all regions" do
-        visit "/region_admin/food_types"
+      it 'can see the list of food types in all regions' do
+        visit '/region_admin/food_types'
 
-        expect(page).to have_content("Boulder food type")
-        expect(page).to have_content("Denver food type")
+        expect(page).to have_content('Boulder food type')
+        expect(page).to have_content('Denver food type')
       end
     end
 
-    context "as a visitor" do
-      it "redirects to sign in" do
-        visit "/region_admin/food_types"
+    context 'as a visitor' do
+      it 'redirects to sign in' do
+        visit '/region_admin/food_types'
 
-        expect(page.current_path).to eq("/volunteers/sign_in")
+        expect(page.current_path).to eq('/volunteers/sign_in')
       end
     end
 
-    context "as a volunteer" do
+    context 'as a volunteer' do
       let(:volunteer) { create(:volunteer, regions: [boulder], assigned: true) }
 
       before do
         login volunteer
       end
 
-      it "redirects to home" do
-        visit "/region_admin/food_types"
+      it 'redirects to home' do
+        visit '/region_admin/food_types'
 
-        expect(page.current_path).to eq("/")
+        expect(page.current_path).to eq('/')
       end
     end
   end

--- a/spec/features/region_admin/food_types/update_spec.rb
+++ b/spec/features/region_admin/food_types/update_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Region Admin Food Types" do
-
-  feature "Updating an existing food type" do
+RSpec.describe 'Region Admin Food Types' do
+  feature 'Updating an existing food type' do
     let(:boulder) { create(:region) }
     let(:denver)  { create(:region) }
 
@@ -10,11 +9,11 @@ RSpec.describe "Region Admin Food Types" do
       create(
         :food_type,
         region: boulder,
-        name:   "Canned"
+        name:   'Canned'
       )
     end
 
-    context "as a region admin" do
+    context 'as a region admin' do
       let(:volunteer) { create(:volunteer, regions: [], assigned: true) }
 
       before do
@@ -23,24 +22,24 @@ RSpec.describe "Region Admin Food Types" do
 
         login volunteer
       end
-      
-      context "on success" do
-        it "updates the food type" do
-          visit "/region_admin/food_types/#{food_type.id}/edit"
 
-          fill_in :food_type_name, with: "Frozen"
-          click_on "Update Food type"
+      context 'on success' do
+        it 'updates the food type' do
+          visit '/region_admin/food_types/#{food_type.id}/edit'
 
-          expect(page).to have_content("Updated successfully.")
+          fill_in :food_type_name, with: 'Frozen'
+          click_on 'Update Food type'
+
+          expect(page).to have_content('Updated successfully.')
         end
       end
 
-      context "on failure" do
+      context 'on failure' do
         # Can't fail thru the UI. RF 1-18-17
       end
     end
 
-    context "as a super admin" do
+    context 'as a super admin' do
       let(:volunteer) { create(:volunteer, regions: [], assigned: true, admin: true) }
 
       before do
@@ -49,35 +48,35 @@ RSpec.describe "Region Admin Food Types" do
         login volunteer
       end
 
-      it "updates the food type" do
-        visit "/region_admin/food_types/#{food_type.id}/edit"
+      it 'updates the food type' do
+        visit '/region_admin/food_types/#{food_type.id}/edit'
 
-        fill_in :food_type_name, with: "Frozen"
-        click_on "Update Food type"
+        fill_in :food_type_name, with: 'Frozen'
+        click_on 'Update Food type'
 
-        expect(page).to have_content("Updated successfully.")
+        expect(page).to have_content('Updated successfully.')
       end
     end
 
-    context "as a visitor" do
-      it "redirects to sign in" do
-        visit "/region_admin/food_types/#{food_type.id}/edit"
+    context 'as a visitor' do
+      it 'redirects to sign in' do
+        visit '/region_admin/food_types/#{food_type.id}/edit'
 
-        expect(page.current_path).to eq("/volunteers/sign_in")
+        expect(page.current_path).to eq('/volunteers/sign_in')
       end
     end
 
-    context "as a volunteer" do
+    context 'as a volunteer' do
       let(:volunteer) { create(:volunteer, regions: [boulder], assigned: true) }
 
       before do
         login volunteer
       end
 
-      it "redirects to home" do
-        visit "/region_admin/food_types/#{food_type.id}/edit"
+      it 'redirects to home' do
+        visit '/region_admin/food_types/#{food_type.id}/edit'
 
-        expect(page.current_path).to eq("/")
+        expect(page.current_path).to eq('/')
       end
     end
   end

--- a/spec/features/region_admin/food_types/update_spec.rb
+++ b/spec/features/region_admin/food_types/update_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Region Admin Food Types' do
 
       context 'on success' do
         it 'updates the food type' do
-          visit '/region_admin/food_types/#{food_type.id}/edit'
+          visit edit_region_admin_food_type_path(food_type.id)
 
           fill_in :food_type_name, with: 'Frozen'
           click_on 'Update Food type'
@@ -49,7 +49,7 @@ RSpec.describe 'Region Admin Food Types' do
       end
 
       it 'updates the food type' do
-        visit '/region_admin/food_types/#{food_type.id}/edit'
+        visit edit_region_admin_food_type_path(food_type.id)
 
         fill_in :food_type_name, with: 'Frozen'
         click_on 'Update Food type'
@@ -60,7 +60,7 @@ RSpec.describe 'Region Admin Food Types' do
 
     context 'as a visitor' do
       it 'redirects to sign in' do
-        visit '/region_admin/food_types/#{food_type.id}/edit'
+        visit edit_region_admin_food_type_path(food_type.id)
 
         expect(page.current_path).to eq('/volunteers/sign_in')
       end
@@ -74,7 +74,7 @@ RSpec.describe 'Region Admin Food Types' do
       end
 
       it 'redirects to home' do
-        visit '/region_admin/food_types/#{food_type.id}/edit'
+        visit edit_region_admin_food_type_path(food_type.id)
 
         expect(page.current_path).to eq('/')
       end

--- a/spec/features/shifts_needing_coverage_spec.rb
+++ b/spec/features/shifts_needing_coverage_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Shifts needing coverage' do
     it 'they see the shifts in their region that need covering' do
       visit root_path
 
-      within page.find('h2', text: 'Shifts Needing Covering').find('+table') do
+      within page.find('h2', text: 'Shifts Needing Covering').find('+ table') do
         expect(page).to have_link(log.donor.name, href: location_path(log.donor))
         expect(page).to have_button('Take')
         log.food_types.each do |type|
@@ -29,7 +29,7 @@ RSpec.describe 'Shifts needing coverage' do
 
       visit root_path
 
-      within page.find('h2', text: 'Shifts Needing Covering').find('+table') do
+      within page.find('h2', text: 'Shifts Needing Covering').find('+ table') do
         expect(page).to_not have_link(other_region_log.donor.name, href: location_path(other_region_log.donor))
       end
     end

--- a/spec/interactors/region_admin/create_food_type_spec.rb
+++ b/spec/interactors/region_admin/create_food_type_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe RegionAdmin::CreateFoodType do
-
-  describe ".call" do
+  describe '.call' do
     let(:boulder) { create(:region, name: 'Boulder') }
 
-    context "on success" do
+    context 'on success' do
       let(:volunteer) { create(:volunteer, active: true) }
 
       subject do
@@ -17,8 +16,8 @@ RSpec.describe RegionAdmin::CreateFoodType do
           }
         )
       end
-      
-      context "as a region admin" do
+
+      context 'as a region admin' do
         before do
           create(
             :assignment,
@@ -28,11 +27,11 @@ RSpec.describe RegionAdmin::CreateFoodType do
           )
         end
 
-        it "returns success" do
+        it 'returns success' do
           expect(subject.success?).to eq(true)
         end
 
-        it "creates a new food type" do
+        it 'creates a new food type' do
           expect{
             subject
           }.to change {
@@ -41,17 +40,17 @@ RSpec.describe RegionAdmin::CreateFoodType do
         end
       end
 
-      context "as a super admin" do
+      context 'as a super admin' do
         before do
           volunteer.admin = true
           volunteer.save
         end
 
-        it "returns success" do
+        it 'returns success' do
           expect(subject.success?).to eq(true)
         end
 
-        it "creates a new food type" do
+        it 'creates a new food type' do
           expect{
             subject
           }.to change {
@@ -61,8 +60,8 @@ RSpec.describe RegionAdmin::CreateFoodType do
       end
     end
 
-    context "on failure" do
-      context "with invalid authorization" do
+    context 'on failure' do
+      context 'with invalid authorization' do
         let(:denver) { create(:region, name: 'Denver') }
 
         let(:volunteer) { create(:volunteer, active: true) }
@@ -86,12 +85,12 @@ RSpec.describe RegionAdmin::CreateFoodType do
           )
         end
 
-        it "returns failure" do
+        it 'returns failure' do
           expect(subject.failure?).to eq(true)
         end
       end
 
-      context "with invalid params" do
+      context 'with invalid params' do
         let(:volunteer) { create(:volunteer, active: true) }
 
         subject do
@@ -104,11 +103,11 @@ RSpec.describe RegionAdmin::CreateFoodType do
           )
         end
 
-        it "returns failure" do
+        it 'returns failure' do
           expect(subject.failure?).to eq(true)
         end
 
-        it "does not create a food type" do
+        it 'does not create a food type' do
           expect{
             subject
           }.to_not change {
@@ -116,7 +115,7 @@ RSpec.describe RegionAdmin::CreateFoodType do
           }
         end
 
-        it "sets the food type" do
+        it 'sets the food type' do
           expect(subject.food_type).to_not be_nil
         end
       end

--- a/spec/interactors/region_admin/delete_food_type_spec.rb
+++ b/spec/interactors/region_admin/delete_food_type_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe RegionAdmin::DeleteFoodType do
-
-  describe ".call" do
+  describe '.call' do
     let(:boulder) { create(:region, name: 'Boulder') }
 
     let(:food_type) do
@@ -13,17 +12,17 @@ RSpec.describe RegionAdmin::DeleteFoodType do
       )
     end
 
-    context "on success" do
+    context 'on success' do
       let(:volunteer) { create(:volunteer, active: true) }
 
       subject do
         described_class.call(
           volunteer:    volunteer,
-          food_type_id: food_type.id,
+          food_type_id: food_type.id
         )
       end
 
-      context "as a region admin" do
+      context 'as a region admin' do
         before do
           create(
             :assignment,
@@ -33,11 +32,11 @@ RSpec.describe RegionAdmin::DeleteFoodType do
           )
         end
 
-        it "returns success" do
+        it 'returns success' do
           expect(subject.success?).to eq(true)
         end
 
-        it "soft deletes the food type" do
+        it 'soft deletes the food type' do
           expect{
             subject
           }.to change {
@@ -46,17 +45,17 @@ RSpec.describe RegionAdmin::DeleteFoodType do
         end
       end
 
-      context "as a super admin" do
+      context 'as a super admin' do
         before do
           volunteer.admin = true
           volunteer.save
         end
 
-        it "returns success" do
+        it 'returns success' do
           expect(subject.success?).to eq(true)
         end
 
-        it "soft deletes the food type" do
+        it 'soft deletes the food type' do
           expect{
             subject
           }.to change {
@@ -66,18 +65,18 @@ RSpec.describe RegionAdmin::DeleteFoodType do
       end
     end
 
-    context "on failure" do
-      context "with invalid authorization" do
+    context 'on failure' do
+      context 'with invalid authorization' do
         let(:volunteer) { create(:volunteer, active: true) }
 
         subject do
           described_class.call(
             volunteer:    volunteer,
-            food_type_id: food_type.id,
+            food_type_id: food_type.id
           )
         end
 
-        it "returns failure" do
+        it 'returns failure' do
           expect(subject.failure?).to eq(true)
         end
       end

--- a/spec/interactors/region_admin/update_food_type_spec.rb
+++ b/spec/interactors/region_admin/update_food_type_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe RegionAdmin::UpdateFoodType do
-
-  describe ".call" do
+  describe '.call' do
     let(:boulder) { create(:region, name: 'Boulder') }
 
     let(:food_type) do
@@ -13,7 +12,7 @@ RSpec.describe RegionAdmin::UpdateFoodType do
       )
     end
 
-    context "on success" do
+    context 'on success' do
       let(:volunteer) { create(:volunteer, active: true) }
 
       subject do
@@ -26,7 +25,7 @@ RSpec.describe RegionAdmin::UpdateFoodType do
         )
       end
 
-      context "as a region admin" do
+      context 'as a region admin' do
         before do
           create(
             :assignment,
@@ -36,43 +35,43 @@ RSpec.describe RegionAdmin::UpdateFoodType do
           )
         end
 
-        it "returns success" do
+        it 'returns success' do
           expect(subject.success?).to eq(true)
         end
-        
-        it "updates the food type" do
+
+        it 'updates the food type' do
           expect{
             subject
           }.to change{
             food_type.reload.name
           }.from('Produce')
-          .to('Canned')
+            .to('Canned')
         end
       end
 
-      context "as a super admin" do
+      context 'as a super admin' do
         before do
           volunteer.admin = true
           volunteer.save
         end
 
-        it "returns success" do
+        it 'returns success' do
           expect(subject.success?).to eq(true)
         end
-        
-        it "updates the food type" do
+
+        it 'updates the food type' do
           expect{
             subject
           }.to change{
             food_type.reload.name
           }.from('Produce')
-          .to('Canned')
+            .to('Canned')
         end
       end
     end
 
-    context "on failure" do
-      context "with invalid authorization" do
+    context 'on failure' do
+      context 'with invalid authorization' do
         let(:volunteer) { create(:volunteer, active: true) }
 
         subject do
@@ -85,7 +84,7 @@ RSpec.describe RegionAdmin::UpdateFoodType do
           )
         end
 
-        it "returns failure" do
+        it 'returns failure' do
           expect(subject.failure?).to eq(true)
         end
       end


### PR DESCRIPTION
rand(3) will sometimes return 0 in the log factory.

Cleanup of home html code.

## Overview
Occasionally the shifts_needing_coverage_spec.rb will fail based on logic for showing upcoming shifts.

## Details
def home in volunteers_controller.rb looks for `@shifts_needing_cov = Shift.build_shifts(Log.needing_coverage(current_volunteer.region_ids, 7, 10))` which would skip if recipients or donor was nil for a log.

Code cleanup added as well.
