### PR TITLE
De-dup log_volunteers

### DIFF
--- a/app/models/log_volunteer.rb
+++ b/app/models/log_volunteer.rb
@@ -7,4 +7,10 @@ class LogVolunteer < ActiveRecord::Base
 
   accepts_nested_attributes_for :volunteer
 
+  validate :prevent_active_duplicates
+
+  def prevent_active_duplicates
+    existing_active = self.class.where(log_id: log_id, volunteer_id: volunteer_id, active: true)
+    errors.add(:base, "volunteer #{volunteer_id} is already assigned to log #{log_id}") if active && existing_active.any?
+  end
 end

--- a/lib/de_dup_log_volunteers.rb
+++ b/lib/de_dup_log_volunteers.rb
@@ -1,0 +1,20 @@
+class DeDupLogVolunteers
+  def self.de_duplicate
+    ActiveRecord::Base.connection.execute <<-SQL
+WITH t AS (
+  SELECT
+    id,
+    volunteer_id,
+    log_id,
+    rank() OVER (
+      PARTITION BY volunteer_id, log_id ORDER BY created_at DESC
+    ) AS rank
+  FROM log_volunteers
+  WHERE active = true
+)
+UPDATE log_volunteers
+SET active = false
+WHERE id IN (SELECT id FROM t WHERE rank > 1);
+    SQL
+  end
+end

--- a/spec/lib/de_dup_log_volunteers_spec.rb
+++ b/spec/lib/de_dup_log_volunteers_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+require 'de_dup_log_volunteers'
+
+RSpec.describe DeDupLogVolunteers do
+  describe '::de_duplicate' do
+    subject { described_class.de_duplicate }
+
+    let(:log) { create(:log) }
+    let(:volunteer) { create(:volunteer) }
+
+    let!(:log_volunteer_dups) {
+      Array.new(3) do |i|
+        create(:log_volunteer, log: log, volunteer: volunteer, created_at: i.days.ago)
+      end
+    }
+
+    it 'does not delete any data' do
+      expect { subject }.not_to change { LogVolunteer.count }
+    end
+
+    it 'finds all active duplicates and sets all but the most recent to inactive' do
+      expect(log_volunteer_dups.map(&:active)).to all(eq(true))
+
+      subject
+
+      log_volunteer_dups.each(&:reload)
+
+      expect(log_volunteer_dups.first.active).to eq(true)
+      expect(log_volunteer_dups[1..-1].map(&:active)).to all(eq(false))
+    end
+  end
+end

--- a/spec/lib/de_dup_log_volunteers_spec.rb
+++ b/spec/lib/de_dup_log_volunteers_spec.rb
@@ -9,8 +9,12 @@ RSpec.describe DeDupLogVolunteers do
     let(:volunteer) { create(:volunteer) }
 
     let!(:log_volunteer_dups) {
-      Array.new(3) do |i|
-        create(:log_volunteer, log: log, volunteer: volunteer, created_at: i.days.ago)
+      begin
+        Array.new(3) do |i|
+          create(:log_volunteer, log: log, volunteer: volunteer, created_at: i.days.ago)
+        end
+      rescue ActiveRecord::RecordInvalid
+        skip 'duplicate log_volunteers with active = true are now prevented'
       end
     }
 

--- a/spec/models/log_volunteer_spec.rb
+++ b/spec/models/log_volunteer_spec.rb
@@ -1,11 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe LogVolunteer do
-  describe 'this file needs to be completed' do
-    let(:super_admin) { create(:volunteer, admin: true) }
+  let(:log_id) { 100 }
+  let(:volunteer_id) { 200 }
 
-    xit 'validates super_admin' do
-      expect(super_admin).to be_valid
-    end
+  it 'prevents active duplicate records' do
+    LogVolunteer.create!(log_id: log_id, volunteer_id: volunteer_id, active: true)
+
+    expect do
+      LogVolunteer.create!(log_id: log_id, volunteer_id: volunteer_id, active: true)
+    end.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  it 'allows inactive duplicate records' do
+    LogVolunteer.create!(log_id: log_id, volunteer_id: volunteer_id, active: true)
+
+    expect do
+      LogVolunteer.create!(log_id: log_id, volunteer_id: volunteer_id, active: false)
+      LogVolunteer.create!(log_id: log_id, volunteer_id: volunteer_id, active: false)
+    end.not_to raise_error(ActiveRecord::RecordInvalid)
   end
 end


### PR DESCRIPTION
This is an alternative implementation of #80 that uses an ActiveRecord validation instead of a SQL unique index to prevent duplicate `log_volunteers` records. The SQL unique index was not an option because it couldn't be adequately represented in `schema.rb`.