### PR TITLE
Shift Volunteer stats views updates

### DIFF
--- a/app/assets/stylesheets/base/_headers.scss
+++ b/app/assets/stylesheets/base/_headers.scss
@@ -8,7 +8,9 @@ h2 {
     border-top: 1px solid #EEEEEE;
     border-bottom: 1px solid #EEEEEE;
     font-size: 150%;
+    height: auto;
     margin: 10px 0 0;
+    overflow: hidden;
     padding: 10px 0 10px 0;
     &.first {
       border-top: 0px;

--- a/app/assets/stylesheets/modules/_buttons.scss
+++ b/app/assets/stylesheets/modules/_buttons.scss
@@ -9,3 +9,9 @@ button.btn {
   &.fill{
   }
 }
+.btn {
+  &.in-text-header {
+    margin-bottom: 5px;
+  }
+}
+

--- a/app/models/food_type.rb
+++ b/app/models/food_type.rb
@@ -1,5 +1,4 @@
 class FoodType < ActiveRecord::Base
-
   belongs_to :region
 
   has_many :schedule_parts
@@ -8,9 +7,7 @@ class FoodType < ActiveRecord::Base
   has_many :logs, through: :log_parts
 
   default_scope { where(active: true) }
-
   scope :active, -> { where(active: true) }
-
   scope :regional, ->(ids) { where(region_id: ids) }
 
   attr_accessible :name, :region_id

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -32,21 +32,15 @@ class Region < ActiveRecord::Base
   end
 
   def has_sellers?
-    locations.any? do |location|
-      location.location_type == Location::LOCATION_TYPES.invert['Seller']
-    end
+    locations.where(location_type: Location::LOCATION_TYPES.invert['Seller']).any?
   end
 
   def has_buyers?
-    locations.any? do |location|
-      location.location_type == Location::LOCATION_TYPES.invert['Buyer']
-    end
+    locations.where(location_type: Location::LOCATION_TYPES.invert['Buyer']).any?
   end
 
   def has_hubs?
-    locations.any? do |location|
-      location.location_type == Location::LOCATION_TYPES.invert['Hub']
-    end
+    locations.where(location_type: Location::LOCATION_TYPES.invert['Hub']).any?
   end
 
   def has_handbook?

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -7,10 +7,15 @@ class Shift
            :schedule_chain,
            to: :first_log
 
+  def self.build_shifts_eagerly(log_ids)
+    logs = Log.includes(:schedule_chain).find(log_ids)
+    Shift.build_shifts(logs)
+  end
+
   def self.build_shifts(logs)
     shifts = []
     group = {}
-    logs.each { |log|
+    logs.each do |log|
       if log.schedule_chain.nil?
         shifts << [log]
       else
@@ -21,7 +26,7 @@ class Shift
         end
         shifts[group[key]] << log
       end
-    }
+    end
 
     shifts.map { |shift_logs| new(shift_logs) }
   end

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -109,10 +109,10 @@ class Volunteer < ActiveRecord::Base
   def region_admin?(region = nil, strict = true)
     return true if !strict && super_admin?
 
-    admin_regions = admin_region_ids(strict)
+    admin_regions_ids = admin_region_ids(strict)
     if region.nil?
-      return true unless admin_regions.empty?
-    elsif admin_regions.include?(region.id)
+      return true unless admin_regions_ids.empty?
+    elsif admin_regions_ids.include?(region.id)
       return true
     end
 

--- a/app/views/logs/_form.html.erb
+++ b/app/views/logs/_form.html.erb
@@ -99,7 +99,7 @@
                   <%= fields_for :log_parts, lp, :index => "update_#{lp.id}" do |f2| %>
                     <tr class="log_part" style="background: <%= lp.required ? "lightgrey" : "white" %>;">
                       <td>
-                        <%= f2.select(:food_type_id, @food_types,{:include_blank => true}, {class: "form-control"}) %>
+                        <%= f2.select(:food_type_id, @food_types,{include_blank: true}, {class: "form-control"}) %>
                       </td>
                       <td>
                         <%= f2.text_field(:weight, size: 5, class: "form-control") %>

--- a/app/views/logs/edit.html.erb
+++ b/app/views/logs/edit.html.erb
@@ -1,2 +1,2 @@
 <h2>Edit Pick-up Report</h2>
-<%= render :partial => "form" %>
+<%= render partial: "form" %>

--- a/app/views/volunteers/shift_stats.html.erb
+++ b/app/views/volunteers/shift_stats.html.erb
@@ -1,0 +1,67 @@
+<div class="row">
+  <div class="col-sm-6">
+    <%= form_tag("/volunteers/shift_stats", method: "get") do %>
+      View For <%= select_tag("region_id", options_for_select(@regions.collect{ |region| [region.name, region.id] })) %>
+      <%= submit_tag("Go", class: 'btn btn-primary') %>
+    <% end %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-12">
+    <h2 class="section-head">Shift Statistics</h2>
+
+    <h2><%= @region.try(:name) %> Shifts Completed - All Time</h2>
+    <table class="datatable">
+      <thead>
+        <th>Volunteer</th>
+        <th>Number of Shifts</th>
+      </thead>
+      <tbody>
+        <% @shifts_by_volunteer.each do |volunteer, shifts| %>
+          <tr>
+            <td>
+              <%= volunteer.name %>
+            </td>
+            <td>
+              <%= shifts.length %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <!-- <br><br>
+    <h2>Top 25 Shifts By Month</h2>
+    <table class="datatable">
+      <thead>
+        <th>Shift Month</th>
+        <th>Number of Shifts</th>
+      </thead>
+      <tbody>
+        < %#  @top_shifts.each do |month, shifts| %>
+          <tr>
+            <td>
+              < %= #month %>
+            </td>
+            <td>
+              < % = #shifts.length %>
+            </td>
+          </tr>
+        < % # end %>
+      </tbody>
+    </table> -->
+
+    <br><br>
+  </div>
+</div>
+
+<% content_for :scripts do %>
+  <script type="text/javascript">
+    $(function () {
+      $('.datatable').dataTable( {
+        'iDisplayLength' : 10
+      });
+    });
+  </script>
+<% end %>

--- a/app/views/volunteers/stats.html.erb
+++ b/app/views/volunteers/stats.html.erb
@@ -1,27 +1,64 @@
 <div class="row">
   <div class="col-sm-12">
-    <h2 class="section-head">Volunteer Statistics</h2>
+    <h2 class="section-head">
+      Volunteer Statistics
+      <%= link_to 'View Shift Stats', shift_stats_volunteers_path, class: 'pull-right btn btn-primary in-text-header' %>
+    </h2>
 
     <h2>Last 12 Months</h2>
-    <table class="datatable"><thead><th>Volunteer<th>Amount<th>Count</thead><tbody>
-    <% @per_volunteer.each{ |v| %>
-      <tr><td><%= v.name %><td><%= v.sum %><td><%= v.count %>
-    <% } %>
-    </tbody></table>
+    <table class="datatable">
+      <thead>
+        <th>Volunteer</th>
+        <th>Weight of Food Picked Up</th>
+        <th># of Pickups</th>
+      </thead>
+      <tbody>
+        <% @logs_per_volunteer_year.each do |volunteer| %>
+          <tr>
+            <td>
+              <%= volunteer.name %>
+            </td>
+            <td>
+              <%= volunteer.sum %>
+            </td>
+            <td>
+              <%= volunteer.count %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
 
     <br><br>
 
     <h2>Last Month</h2>
-    <table class="datatable"><thead><th>Volunteer<th>Amount<th>Count</thead><tbody>
-    <% @per_volunteer2.each{ |v| %>
-      <tr><td><%= v.name %><td><%= v.sum %><td><%= v.count %>
-    <% } %>
-    </tbody></table>
+    <table class="datatable">
+      <thead>
+        <th>Volunteer</th>
+        <th>Weight of Food Picked Up</th>
+        <th># of Pickups</th>
+      </thead>
+      <tbody>
+        <% @logs_per_volunteer_month.each do |volunteer| %>
+          <tr>
+            <td>
+              <%= volunteer.name %>
+            </td>
+            <td>
+              <%= volunteer.sum %>
+            </td>
+            <td>
+              <%= volunteer.count %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
 
     <br><br>
 
     <h2>Attrition</h2>
-    Volunteers who have done pickups, but not for 90 days or more.
+    <p>Volunteers who have done pickups, but not for 90 days or more.</p>
     <table class="datatable"><thead><th>Volunteer<th>Email<th>Last Pickup<th>Num Pickups</thead><tbody>
     <%
        @lazy_volunteers.each{ |v|

--- a/config/initializers/query_troubleshooting.rb
+++ b/config/initializers/query_troubleshooting.rb
@@ -1,0 +1,8 @@
+# Uncomment this to get a backtrace of your bad query.
+# ActiveSupport::Notifications.subscribe("sql.active_record") do |_, _, _, _, details|
+#   if details[:sql] =~ /SELECT \"regions\".*/
+#     puts "*" * 50
+#     puts caller.join("\n")
+#     puts "*" * 50
+#   end
+# end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,6 +101,7 @@ Webapp::Application.routes.draw do
       get :super_admin
       get :region_admin
       get :stats
+      get :shift_stats
       get :switch_user
       get :knight
       get :index


### PR DESCRIPTION
## Overview
The BFR Volunteer Coordinator would like to see top # of shifts for volunteers by region all time.

## Details
When going to volunteer stats you can now to go shift stats from that page to see top # of completed shifts all time.

## Notes
This includes code/html/space cleanup and optimizations for lookups of regions site wide. The nav was calling functions that did individual region lookups. I updated shift.rb to add an eager load method to grab logs and schedule chains and THEN build shifts. This prevents multiple hits to schedule chains table .

I tested it and locally 11-12 seconds initially w/o eager loading of schedule chains and 7.3s after.