### PR TITLE
Chore / Removed a Rubocop TODO, improved flash errors

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,11 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-Lint/UselessComparison:
-  Exclude:
-    - 'app/models/location.rb'
-
 # Offense count: 80
 Metrics/AbcSize:
   Max: 147

--- a/app/controllers/absences_controller.rb
+++ b/app/controllers/absences_controller.rb
@@ -100,7 +100,7 @@ class AbsencesController < ApplicationController
         flash[:notice] = "Thanks for scheduling an absence, if you would like to pick one up to replace it go here: <a href=\"#{open_logs_path}\">cover shifts list</a>.<br><br>#{n+ns} shifts will be skipped (12 is the max at one time, #{ns} were already present). You can see your scheduled absences <a href=\"#{absences_path}\">here</a>.".html_safe
         render :new
       else
-        flash[:warning] = "Didn't save successfully :("
+        flash[:error] = "Didn't save successfully :(. #{@absence.errors.full_messages.to_sentence}"
         render :new
       end
     end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -96,7 +96,7 @@ class LocationsController < ApplicationController
         index
       end
     else
-      flash[:notice] = "Didn't save successfully :("
+      flash[:error] = "Didn't save successfully :(. #{@location.errors.full_messages.to_sentence}"
       render :new
     end
   end
@@ -122,9 +122,8 @@ class LocationsController < ApplicationController
         index
       end
     else
-      flash[:error] = 'Update failed :('
+      flash[:error] = "Didn't update successfully :(. #{@location.errors.full_messages.to_sentence}"
       render :edit
     end
   end
-
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,7 +1,6 @@
 require 'prawn/table'
 
 class LogsController < ApplicationController
-
   before_filter :authenticate_volunteer!, :except => :stats_service
   before_filter :admin_only, :only => [:today, :tomorrow, :yesterday, :being_covered, :tardy, :receipt, :new, :create, :stats, :export]
 
@@ -184,7 +183,7 @@ class LogsController < ApplicationController
         index
       end
     else
-      flash[:notice] = "Didn't save successfully :(. #{@log.errors.full_messages.to_sentence}"
+      flash[:error] = "Didn't save successfully :(. #{@log.errors.full_messages.to_sentence}"
       render :new
     end
   end
@@ -256,7 +255,7 @@ class LogsController < ApplicationController
         end
       end
     else
-      flash[:error] = 'Update failed :('
+      flash[:error] = "Didn't update successfully :(. #{@log.errors.full_messages.to_sentence}"
       respond_to do |format|
         format.json { render json: {error: 1, message: flash[:notice] } }
         format.html { render :edit }

--- a/app/controllers/schedule_chains_controller.rb
+++ b/app/controllers/schedule_chains_controller.rb
@@ -127,7 +127,7 @@ class ScheduleChainsController < ApplicationController
       flash[:notice] = 'Created successfully'
       index
     else
-      flash[:error] = "Didn't save successfully :("
+      flash[:error] = "Didn't save successfully :(. #{@schedule.errors.full_messages.to_sentence}"
       render :new
     end
   end
@@ -180,7 +180,7 @@ class ScheduleChainsController < ApplicationController
       flash[:notice] = 'Updated Successfully'
       index
     else
-      flash[:error] = 'Update failed :('
+      flash[:error] = "Didn't update successfully :(. #{@schedule.errors.full_messages.to_sentence}"
       render :edit
     end
   end

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -131,7 +131,7 @@ class VolunteersController < ApplicationController
         index
       end
     else
-      flash[:error] = "Didn't save successfully :("
+      flash[:error] = "Didn't save successfully :(. #{@volunteer.errors.full_messages.to_sentence}"
       render :new
     end
   end
@@ -164,7 +164,7 @@ class VolunteersController < ApplicationController
         index
       end
     else
-      flash[:error] = 'Update failed :('
+      flash[:error] = "Didn't update successfully :(. #{@volunteer.errors.full_messages.to_sentence}"
       render :edit
     end
   end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -140,7 +140,7 @@ class Location < ActiveRecord::Base
     (0..6).each do |index|
       if open_on_day? index
         prefix = 'day'+index.to_s
-        if read_day_info(prefix+'_start') > read_day_info(prefix+'_start')
+        if read_day_info(prefix + '_start') > read_day_info(prefix + '_end')
           errors.add(prefix+'_status', 'must have an end time AFTER the start time')
         end
       end

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe AssignmentsController do
-
   xit 'asserts the truth' do
     expect(true).to be_truthy
   end

--- a/spec/controllers/cell_carriers_controller_spec.rb
+++ b/spec/controllers/cell_carriers_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe CellCarriersController do
-
   xit 'asserts the truth' do
     expect(true).to be_truthy
   end

--- a/spec/controllers/regions_controller_spec.rb
+++ b/spec/controllers/regions_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe RegionsController do
-
   xit 'asserts the truth' do
     expect(true).to be_truthy
   end

--- a/spec/controllers/scale_types_controller.rb
+++ b/spec/controllers/scale_types_controller.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ScaleTypesController do
-
   xit 'asserts the truth' do
     expect(true).to be_truthy
   end

--- a/spec/controllers/schedule_chains_controller_spec.rb
+++ b/spec/controllers/schedule_chains_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ScheduleChainsController do
-
   xit 'asserts the truth' do
     expect(true).to be_truthy
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe SessionsController do
-
   xit 'asserts the truth' do
     expect(true).to be_truthy
   end

--- a/spec/controllers/transport_types_controller_spec.rb
+++ b/spec/controllers/transport_types_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe TransportTypesController do
-
   xit 'asserts the truth' do
     expect(true).to be_truthy
   end

--- a/spec/controllers/waivers_controller_spec.rb
+++ b/spec/controllers/waivers_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe WaiversController do
-
   xit 'asserts the truth' do
     expect(true).to be_truthy
   end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Location do
-
   describe 'is_donor' do
     let(:donor_type) do
       described_class::LOCATION_TYPES.invert['Donor']


### PR DESCRIPTION
## Overview

First PR to help—tackled some low-hanging rubocop fruit. Caught a small validation bug with that rule.

## Details

- Fixed Rubocop whitespace issues that were not ignored
- Fixed only instance of same variable comparison, which fixed a broken validation
- Added sentence version of errors to all flash messages. May not be the prettiest, but will help the user / dev figure out what happened.

## Screenshots/Screencasts

<img width="951" alt="screen shot 2017-06-28 at 8 28 43 pm" src="https://user-images.githubusercontent.com/1911028/27668840-996cced2-5c40-11e7-9257-210b00836005.png">
