### PR TITLE
Fix name of task to generate logs in rake sample_region output

### DIFF
--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -11,7 +11,7 @@ namespace :db do
       Created region ##{region.id}: '#{region.name}'"
         with admin(s): #{region.volunteers.where(assignments: { admin: true }).map(&:email).join(', ')}"
 
-      Run `rake foodrobot:generate_log_entries` to generate log records for the newly created schedule chains.
+      Run `rake foodrobot:generate_logs` to generate log records for the newly created schedule chains.
     EOF
   end
 end


### PR DESCRIPTION
`generate_log_entries` is not a thing. We want to refer to https://github.com/boulder-food-rescue/food-rescue-robot/blob/ef/fix_task_name/lib/tasks/foodrobot.rake#L5