### PR TITLE
Shiftless Volunteers query perf + integration test

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -32,9 +32,7 @@ class VolunteersController < ApplicationController
   end
 
   def shiftless
-    @volunteers = Volunteer.all.keep_if do |volunteer|
-      ((volunteer.region_ids & current_volunteer.region_ids).length > 0) && volunteer.schedule_chains.length == 0
-    end
+    @volunteers = Volunteer.active_but_shiftless(current_volunteer.region_ids)
     @header = 'Shiftless Volunteers'
     render :index
   end

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -185,6 +185,18 @@ class Volunteer < ActiveRecord::Base
       compact
   end
 
+  def self.active_but_shiftless(region_ids)
+    includes(:regions)
+      .where(regions: { id: region_ids })
+      .where('regions.id' => region_ids)
+      .where('(SELECT COUNT(*) FROM schedule_chains ' \
+            'INNER JOIN schedule_volunteers ON ' \
+            'schedule_chains.id = schedule_volunteers.schedule_chain_id ' \
+            "WHERE schedule_chains.active = 't' " \
+            'AND schedule_volunteers.volunteer_id = volunteers.id ' \
+            "AND schedule_volunteers.active = 't') = 0")
+  end
+
   private
 
   # better first-time experience: if there is only one region, add the user to

--- a/spec/features/region_admin/shiftless_volunteers_spec.rb
+++ b/spec/features/region_admin/shiftless_volunteers_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe 'Region Admin Shiftless Volunteers' do
+  feature 'Viewing shiftless volunteers' do
+    let(:boulder) { create(:region, name: 'Boulder') }
+    let(:denver) { create(:region, name: 'Denver') }
+
+    context 'as a region admin' do
+      let(:current_volunteer) { create(:volunteer, regions: [], assigned: true) }
+      let(:shiftless_volunteer) { create(:volunteer, assigned: true) }
+      let(:shiftless_volunteer_denver) { create(:volunteer, regions: [denver], assigned: true) }
+      let(:volunteer_with_shifts) { create(:volunteer, assigned: true) }
+      let(:schedule_chain) { create(:schedule_chain, region: boulder) }
+
+      before do
+        create(:assignment, :admin, volunteer: current_volunteer, region: boulder)
+        create(:assignment, volunteer: shiftless_volunteer, region: boulder)
+        create(:assignment, volunteer: shiftless_volunteer_denver, region: denver)
+        create(:assignment, volunteer: volunteer_with_shifts, region: boulder)
+        create(:schedule_volunteer, volunteer: volunteer_with_shifts, schedule_chain: schedule_chain)
+
+        login current_volunteer
+      end
+
+      it 'displays volunteers without shifts' do
+        visit '/volunteers/shiftless'
+
+        expect(page).to have_content(shiftless_volunteer.name)
+        expect(page).to_not have_content(volunteer_with_shifts.name)
+        expect(page).to_not have_content(shiftless_volunteer_denver.name)
+        expect(page).to have_content('Email List')
+      end
+    end
+
+    context 'as a volunteer' do
+      let(:volunteer) { create(:volunteer, regions: [boulder], assigned: true) }
+
+      before do
+        login volunteer
+      end
+
+      it 'redirects to home' do
+        visit '/volunteers/shiftless'
+
+        expect(page.current_path).to eq('/')
+      end
+    end
+  end
+end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -114,6 +114,38 @@ RSpec.describe Volunteer do
     end
   end
 
+  describe '::active_but_shiftless' do
+    let(:boulder) { create(:region, name: 'Boulder') }
+    let(:denver) { create(:region, name: 'Denver') }
+
+    let(:shiftless_volunteer) { create(:volunteer, assigned: true) }
+    let(:shiftless_volunteer_denver) { create(:volunteer, regions: [denver], assigned: true) }
+    let(:volunteer_with_shifts) { create(:volunteer, assigned: true) }
+    let(:schedule_chain) { create(:schedule_chain, region: boulder) }
+
+    subject { described_class.active_but_shiftless([boulder.id]) }
+
+    before do
+      create(:assignment, volunteer: shiftless_volunteer, region: boulder)
+      create(:assignment, volunteer: shiftless_volunteer_denver, region: denver)
+      create(:assignment, volunteer: volunteer_with_shifts, region: boulder)
+
+      create(:schedule_volunteer, volunteer: volunteer_with_shifts, schedule_chain: schedule_chain)
+    end
+
+    it 'includes only volunteers active in that regions' do
+      expect(subject).to match_array([shiftless_volunteer])
+    end
+
+    context 'when multiple region ids are specified' do
+      subject { described_class.active_but_shiftless([boulder.id, denver.id]) }
+
+      it 'includes only shiftless volunteers active in those regions' do
+        expect(subject).to match_array([shiftless_volunteer_denver, shiftless_volunteer])
+      end
+    end
+  end
+
   describe '::active' do
     let!(:log_volunteer) { create(:log_volunteer, volunteer: volunteer) }
     let(:log) { log_volunteer.log }


### PR DESCRIPTION
## Overview
Addresses #130 -- Previously, the shiftless volunteers route was loading all volunteers
into memory and performing n<sup>2</sup>+1 database queries to figure
out which ones in the shared regions have no shifts assigned. This was
translated into equivalent SQL

## Details
I thought a count subquery was simpler than an equivalent left join / group / having

## Notes
There remains the question as to whether `current_volunteer.region_ids`
is a decent criteria for finding shiftless volunteers. Another option
might be `current_volunteer.admin_region_ids` ?

