### PR TITLE
add scopes for volunteers

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -50,9 +50,7 @@ class VolunteersController < ApplicationController
   end
 
   def need_training
-    @volunteers = Volunteer.all.keep_if do |volunteer|
-      ((volunteer.region_ids & current_volunteer.region_ids).length > 0) && volunteer.needs_training?
-    end
+    @volunteers =  Volunteer.in_regions(current_volunteer.region_ids).needing_training
     @header = 'Volunteers Needing Training'
     render :index
   end

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -2,6 +2,15 @@
 class Volunteer < ActiveRecord::Base
   default_scope { order('volunteers.name ASC').where(active: true) }
 
+  scope :in_regions, ->(regions) { joins(:regions).where('regions.id IN (?)', Array.wrap(regions)).uniq }
+
+  scope :needing_training, lambda {
+    joins('LEFT JOIN log_volunteers ON log_volunteers.volunteer_id = volunteers.id')
+    .joins('LEFT JOIN logs ON logs.id = log_volunteers.log_id AND logs.complete = TRUE')
+    .where('logs.id IS NULL')
+    .uniq
+  }
+
   belongs_to :transport_type
   belongs_to :cell_carrier
   belongs_to :requested_region, class_name: 'Region'

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -235,4 +235,56 @@ RSpec.describe Volunteer do
       end
     end
   end
+
+  describe 'scope in regions' do
+    let(:region1) { create :region }
+    let(:region2) { create :region }
+    let(:volunteer1) do
+      volunteer = create :volunteer, name: 'a'
+      volunteer.regions << region1
+      volunteer
+    end
+
+    let(:volunteer2) do
+      volunteer = create :volunteer, name: 'b'
+      volunteer.regions << region2
+      volunteer
+    end
+
+    it 'returns the volunteer by region' do
+      expect(described_class.in_regions(region1.id)).to eq([volunteer1])
+    end
+
+    it 'returns the volunteers in multiple regions' do
+      expect(described_class.in_regions([region1.id, region2.id])).to eq([volunteer1, volunteer2])
+    end
+  end
+
+  describe 'scope needing training' do
+    let(:log1) { (create :log_volunteer).log }
+    let(:log2) { (create :log_volunteer).log }
+    let!(:volunteer1) { log1.volunteers.first }
+
+    before do
+      log1.update_attribute(:complete, true)
+    end
+
+    context 'missing log entry' do
+      let!(:volunteer2) { create :volunteer }
+
+      it 'returns volunteer not needing training' do
+        expect(described_class.needing_training).to include(volunteer2)
+        expect(described_class.needing_training).not_to include(volunteer1)
+      end
+    end
+
+    context 'log entry where complete is false' do
+      let!(:volunteer2) { log2.volunteers.first }
+
+      it 'returns volunteer not needing training when log is not complete' do
+        expect(described_class.needing_training).to include(volunteer2)
+        expect(described_class.needing_training).not_to include(volunteer1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Overview
<!-- Required. Why is this important/necessary? -->
This adds query scopes that make some volunteer queries much faster and chainable
## Details
<!-- Optional. List the key features/highlights as bullet points. -->
- `in_regions` scope, which accepts a list of region ids for filtering volunteers
- `needing_training` scope, which returns volunteers without associated logs with `complete: true`
- change in volunteer controller to use new scopes

Issue ref: https://github.com/boulder-food-rescue/food-rescue-robot/issues/141
