### PR TITLE
Updating to generate logs 8 days in advance.

### DIFF
--- a/lib/tasks/foodrobot.rake
+++ b/lib/tasks/foodrobot.rake
@@ -4,8 +4,8 @@ namespace :foodrobot do
 
   task(:generate_logs => :environment) do
     Rails.logger = Logger.new(STDOUT)
-    # Generate entries for the next 8 days (these shouldn't duplicate)
-    9.times { |index| FoodRobot::generate_log_entries(Date.today+index) }
+    # RB 4-28-2018: Generate entries for the next 14 days (these shouldn't create duplicates)
+    15.times { |index| FoodRobot::generate_log_entries(Date.today+index) }
   end
 
   task(:send_reminders => :environment) do

--- a/lib/tasks/foodrobot.rake
+++ b/lib/tasks/foodrobot.rake
@@ -4,13 +4,8 @@ namespace :foodrobot do
 
   task(:generate_logs => :environment) do
     Rails.logger = Logger.new(STDOUT)
-    # Generate entries for the next few days (shouldn't duplicate...)
-    FoodRobot::generate_log_entries(Date.today)
-    FoodRobot::generate_log_entries(Date.today+1)
-    FoodRobot::generate_log_entries(Date.today+2)
-    FoodRobot::generate_log_entries(Date.today+3)
-    FoodRobot::generate_log_entries(Date.today+4)
-    FoodRobot::generate_log_entries(Date.today+5)
+    # Generate entries for the next 8 days (these shouldn't duplicate)
+    9.times { |index| FoodRobot::generate_log_entries(Date.today+index) }
   end
 
   task(:send_reminders => :environment) do


### PR DESCRIPTION
This is slightly cleaner code, but it is not ideal overall.

## Overview
Trello Feature request: generate logs for unclaimed schedule items 8 days in advance.

## Details

The logs auto-generate 5 days in advance right now and region/volunteer coordinators would like it to be 8 days in advance.

## Notes

To not do it this way would require a large refactor. So duct tape and bubblegum it is!