### PR TITLE
Remove volunteer all calls

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,5 @@
 inherit_from: .rubocop_todo.yml
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -155,7 +155,7 @@ class LogsController < ApplicationController
 
   def new
     @region = Region.find(params[:region_id])
-    @log = Log.new(region: @region)
+    @log = Log.new(region_id: @region.id)
     @action = 'create'
     authorize! :create, @log
     session[:my_return_to] = request.referer

--- a/app/helpers/volunteers_helper.rb
+++ b/app/helpers/volunteers_helper.rb
@@ -1,8 +1,21 @@
 module VolunteersHelper
-
   def volunteer_photo_column(record)
     return '' if record.photo_file_name.nil?
     link_to image_tag(record.photo(:thumb)){ record.photo(:medium) }
   end
 
+  # RB 3-23-2018: Return volunteers that are unassigned
+  # and only in the region ids that are passed in
+  # all super admins are filtered out for security purposes
+  def my_admin_volunteers
+    return Volunteer.all if current_volunteer.super_admin?
+
+    unassigned = Volunteer.not_super_admin.unassigned.where(assignments: { admin: false })
+
+    volunteers_in_regions = Volunteer.not_super_admin
+                                     .assigned_to_regions(current_volunteer.admin_region_ids)
+                                     .where(assignments: { admin: false })
+
+    (volunteers_in_regions + unassigned).uniq
+  end
 end

--- a/app/views/absences/_form.html.erb
+++ b/app/views/absences/_form.html.erb
@@ -10,11 +10,7 @@ You can use the form below to schedule an absence. Note that any shift occuring 
             Volunteer:
           </label>
         </td>
-        <% if current_volunteer.super_admin? %>
-          <td><%= f.select(:volunteer_id, Volunteer.all.collect{ |v| [v.name, v.id]}, {}, { class: 'form-control' } ) %></td>
-        <% else %>
-          <td><%= f.select(:volunteer_id, Volunteer.all.collect{ |v| ((v.regions.collect{ |r| r.id } & current_volunteer.admin_region_ids).length > 0 and !v.admin) ? [v.name,v.id] : nil }.compact, {class: "form-control"}) %></td>
-        <% end %>
+        <td><%= f.select(:volunteer_id, my_admin_volunteers.collect { |v| [v.name, v.id] }, {}, { class: 'form-control' } ) %></td>
       </tr>
     <% end %>
 

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -61,7 +61,7 @@
               <br />
               <br />
             <% end %>
-            <%= link_to edit_locations_path(loc), class: 'btn btn-primary' do %>
+            <%= link_to edit_location_path(loc), class: 'btn btn-primary' do %>
               <i class="fa fa-pencil"></i>
               edit
             <% end %><br /><br />

--- a/app/views/volunteers/region_admin.html.erb
+++ b/app/views/volunteers/region_admin.html.erb
@@ -19,7 +19,7 @@
             <label for="volunteer_id">Volunteer:</label>
           </td>
           <td>
-            <%= select_tag(:volunteer_id, options_for_select(Volunteer.with_regions_for_select(@my_admin_volunteers)), { class: "form-control select2" }) %>
+            <%= select_tag(:volunteer_id, options_for_select(Volunteer.with_regions_for_select(my_admin_volunteers)), { class: "form-control select2" }) %>
           </td>
         </tr>
       </table>
@@ -111,7 +111,7 @@
             <label for="volunteer_id">Volunteer:</label>
           </td>
           <td>
-            <%= select_tag(:volunteer_id, options_for_select(Volunteer.with_regions_for_select(@my_admin_volunteers)), {class: "form-control select2"}) %>
+            <%= select_tag(:volunteer_id, options_for_select(Volunteer.with_regions_for_select(my_admin_volunteers)), {class: "form-control select2"}) %>
           </td>
         </tr>
         <tr>

--- a/spec/controllers/volunteers_controller_spec.rb
+++ b/spec/controllers/volunteers_controller_spec.rb
@@ -378,11 +378,6 @@ RSpec.describe VolunteersController do
       subject
       expect(assigns(:my_admin_regions)).to be_empty
     end
-
-    it 'my_admin_volunteers is empty by default' do
-      subject
-      expect(assigns(:my_admin_volunteers)).to eq([])
-    end
   end
 
   describe 'GET #region_admin as admin' do
@@ -404,11 +399,6 @@ RSpec.describe VolunteersController do
       subject
       expect(assigns(:admin_region_ids)).to_not be_nil
       expect(assigns(:admin_region_ids).count).to eq(1)
-    end
-
-    it 'my_admin_volunteers is empty by default' do
-      subject
-      expect(assigns(:my_admin_volunteers)).to eq([admin])
     end
   end
 

--- a/spec/controllers/volunteers_controller_spec.rb
+++ b/spec/controllers/volunteers_controller_spec.rb
@@ -201,12 +201,26 @@ RSpec.describe VolunteersController do
   end
 
   describe 'GET #need_training' do
-    subject { get :need_training }
+    before do
+      create(:log_volunteer)
+      needs_training_voluneer = create(:log_volunteer)
 
-    before { sign_in volunteer }
+      needs_training_voluneer.log.complete = false
+      needs_training_voluneer.log.save!
+
+      sign_in volunteer
+    end
 
     it 'renders the index template' do
+      get :need_training
       expect(subject).to render_template :index
+    end
+
+    it 'only shows volunteers that need training' do
+      allow_any_instance_of(Volunteer).to receive(:needs_training?).and_return(true)
+      get :need_training
+      expect(assigns(:volunteers)).to_not be_nil
+      expect(assigns(:volunteers).count).to eq(1)
     end
   end
 


### PR DESCRIPTION
## Overview
Avoid Volunteer.all calls from certain dropdown builds and fixes a few other errors I ran across. Rebase of #149 
