### PR TITLE
Add rake commands to create and migrate test database.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Set up your environment:
 
 This will check your system for prerequisites (e.g. Ruby version), install dependencies, create a `.env` file, create any missing databases and database users, load the database schema and seed development data.
 
+You may need to insert the secret key manually. Check the `.env` file's SECRET_KEY_BASE. If absent, generate a secret key by using the command below:
+
+`bundle exec rake secret`
+
 ### Manual or Windows
 
 Install dependencies:

--- a/bin/setup
+++ b/bin/setup
@@ -48,13 +48,14 @@ ruby bin/support/bootstrap-database.rb
 echo "==> Loading database schema"
 bundle exec rake db:schema:load
 
-RAILS_ENV=test
-bundle exec rake db:schema:load
 
 echo "==> Seeding development database"
 RAILS_ENV=development
 SEED_USERS_PASSWORD=password
 bundle exec rake db:seed
+
+RAILS_ENV=test bundle exec rake db:create
+RAILS_ENV=test bundle exec rake db:schema:load
 
 cat <<INSTRUCTIONS
 


### PR DESCRIPTION
## Overview
The setup for Linux / Mac specified in the ReadMe did not work on my Mac computer nor my classmate's Mac computer. There were two issues we ran into:
1. The secret key was not generated automatically in the `.env` file.
2. The test database was not created when running the the bin/setup file.

## Details
I added a line to the ReadMe that states you must generate the rake secret key manually.
I also added two lines to the `bin/setup` file which creates a test database and loads the schema. This monkey patch doesn't actually address why the `bootstrap.db` is not generating a test database.

## Notes
<!-- Optional. List additional notes/references as bullet points. Delete if unused. -->

## Screenshots/Screencasts
When the `.env` file sets up the test environment database, it hits an error saying it has already been created:
![screen shot 2018-05-22 at 8 44 54 am](https://user-images.githubusercontent.com/24374609/40370087-b3f360dc-5d9c-11e8-87b9-8efaae4f925e.png)
However, when checking the my databases in psql, I only see a "bfr_webapp_db" and not the associated "bfr_webapp_db_test." 
