### PR TITLE
Generate rescue log if new schedule is one-time, same day

### DIFF
--- a/app/controllers/schedule_chains_controller.rb
+++ b/app/controllers/schedule_chains_controller.rb
@@ -112,7 +112,7 @@ class ScheduleChainsController < ApplicationController
     @schedule = ScheduleChain.new(params[:schedule_chain])
     authorize! :create, @schedule
 
-    if @schedule.save
+    if CreateScheduleChain.call(schedule_chain: @schedule).success?
       flash[:notice] = 'Created successfully'
       index
     else
@@ -249,5 +249,4 @@ class ScheduleChainsController < ApplicationController
   def admin_only
     redirect_to(root_path) unless current_volunteer.any_admin?
   end
-
 end

--- a/app/interactors/create_schedule_chain.rb
+++ b/app/interactors/create_schedule_chain.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class CreateScheduleChain
+  include Interactor
+
+  delegate :schedule_chain,
+           :fail!,
+           to: :context
+
+  def call
+    fail! unless schedule_chain.save
+
+    # These are normally created as part of a daily task, but often that task runs too late
+    # for one-time schedules on the same day.
+    generate_log if schedule_chain.one_time? && schedule_chain.detailed_date.today?
+  end
+
+  private
+
+  def generate_log
+    FoodRobot::LogGenerator::ScheduleChainDecorator.new(schedule_chain).donors.each do |donor|
+      FoodRobot::LogGenerator::LogBuilder.new(Date.today, donor, nil).log.save
+    end
+  end
+end

--- a/app/views/schedule_chains/_form.html.erb
+++ b/app/views/schedule_chains/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for @schedule, url: {action: @action }, class: 'form-horizontal' do |f| %>
+<%= simple_form_for @chain, url: {action: @action }, class: 'form-horizontal' do |f| %>
 
   <%= hidden_field_tag "schedule_chain[region_id]", @region.id %>
 
@@ -44,7 +44,7 @@
         </div>
       </td>
     </tr>
-    <% if current_volunteer.any_admin?(@schedule.region) %>
+    <% if current_volunteer.any_admin?(@chain.region) %>
       <tr>
         <td>
           <label for="schedule_chain_num_volunteers">Needed Volunteers</label>
@@ -93,7 +93,7 @@
       <td>
         <label for="schedule_chain_expected_weight">Expected Weight</label>
         <div class="subtext">
-          Typical weight observed on pickup. Current mean = <%= @schedule.mean_weight.nil? ? "Unknown" : @schedule.mean_weight.round %>, max = <%= @schedule.max_weight.nil? ? "Unknown" : @schedule.max_weight.round %>.
+          Typical weight observed on pickup. Current mean = <%= @chain.mean_weight.nil? ? "Unknown" : @chain.mean_weight.round %>, max = <%= @chain.max_weight.nil? ? "Unknown" : @chain.max_weight.round %>.
         </div>
       </td>
       <td>

--- a/app/views/schedule_chains/index.html.erb
+++ b/app/views/schedule_chains/index.html.erb
@@ -13,7 +13,7 @@
 
 <% if current_volunteer.assignments.length == 0 %>
   <p>You haven't been assigned to any regions, so you can't see anything yet. Ask a coordinator for your region to assign you!</p>
-<% elsif @schedules.length == 0 %>
+<% elsif @chains.length == 0 %>
   <p>Local schedule list is empty.</p>
 <% elsif current_volunteer.regions.length == 0 %>
   <p>You aren't assigned to any regions, so you can't see anything yet. Ask a coordinator in your region to assign you!</p>
@@ -44,7 +44,7 @@
     </thead>
     <tbody>
       <%
-        @schedules.each do |schedule|
+        @chains.each do |schedule|
           row_bgcolor = nil
           if schedule.no_volunteers?
             row_bgcolor = "pink"

--- a/app/views/schedule_chains/show.html.erb
+++ b/app/views/schedule_chains/show.html.erb
@@ -4,15 +4,15 @@
 
     <h2>
       <i class='fa fa-location-arrow'></i>
-      <%= if @schedule.functional?
-              if @schedule.recipient_stops.length == 1
-			    "Delivery to " + @schedule.schedules.last.location.name
+      <%= if @chain.functional?
+              if @chain.recipient_stops.length == 1
+			    "Delivery to " + @chain.schedules.last.location.name
               else
                 routename = "Deliveries to "
-                @schedule.recipient_stops.each do |stop|
+                @chain.recipient_stops.each do |stop|
  		              next if stop.location.nil?
                   routename += stop.location.name
-                  if stop != @schedule.recipient_stops.last
+                  if stop != @chain.recipient_stops.last
                     routename += ", "
                   end
                 end
@@ -22,36 +22,36 @@
 			    "Underspecified Schedule"
 		    end%></h2>
 
-    <% unless @schedule.next_pickup_time.nil? or not @schedule.functional? %>
+    <% unless @chain.next_pickup_time.nil? or not @chain.functional? %>
       <div class="pull-right">
         <a href="http://www.google.com/calendar/event?action=TEMPLATE&text=
-            <%=u "Food Rescue: #{(@schedule.schedules.empty? or @schedule.schedules.first.location.nil?) ? "Unknown" : @schedule.schedules.first.location.name} -> #{(@schedule.schedules.empty? or @schedule.schedules.last.location.nil?) ? "Unknown" : @schedule.schedules.last.location.name}" %>
-            &dates=<%=u @schedule.next_pickup_time[:start].gmtime.strftime("%Y%m%dT%H%M%SZ") %>/<%=u @schedule.next_pickup_time[:stop].gmtime.strftime("%Y%m%dT%H%M%SZ") %>&details=<%=u @schedule.public_notes%>&location=<%=u @schedule.schedules.first.location.address%>&trp=true&sprop=http%3A%2F%2Fboulderfoodrescue.org&sprop=name:Boulder%20Food%20Rescue" target="_blank"><img src="//www.google.com/calendar/images/ext/gc_button6.gif" border=0></a>
+            <%=u "Food Rescue: #{(@chain.schedules.empty? or @chain.schedules.first.location.nil?) ? "Unknown" : @chain.schedules.first.location.name} -> #{(@chain.schedules.empty? or @chain.schedules.last.location.nil?) ? "Unknown" : @chain.schedules.last.location.name}" %>
+            &dates=<%=u @chain.next_pickup_time[:start].gmtime.strftime("%Y%m%dT%H%M%SZ") %>/<%=u @chain.next_pickup_time[:stop].gmtime.strftime("%Y%m%dT%H%M%SZ") %>&details=<%=u @chain.public_notes%>&location=<%=u @chain.schedules.first.location.address%>&trp=true&sprop=http%3A%2F%2Fboulderfoodrescue.org&sprop=name:Boulder%20Food%20Rescue" target="_blank"><img src="//www.google.com/calendar/images/ext/gc_button6.gif" border=0></a>
       </div>
     <% end %>
 
     <p>
-      <%= readable_pickup_timespan @schedule %>
-      <% unless @schedule.next_pickup_time.nil? %>
-        (next pickup <%= @schedule.next_pickup_time[:start].to_s(:long_ordinal) %>)
+      <%= readable_pickup_timespan @chain %>
+      <% unless @chain.next_pickup_time.nil? %>
+        (next pickup <%= @chain.next_pickup_time[:start].to_s(:long_ordinal) %>)
       <% end %>
       .
     </p>
 
-    <% unless @schedule.public_notes.nil? or @schedule.public_notes.strip == "" %>
-      <p><b>Notes:</b> <%= word_wrap(@schedule.public_notes,:line_width => 80).gsub("\n","<br>").html_safe %></p>
+    <% unless @chain.public_notes.nil? or @chain.public_notes.strip == "" %>
+      <p><b>Notes:</b> <%= word_wrap(@chain.public_notes,:line_width => 80).gsub("\n","<br>").html_safe %></p>
     <% end %>
 
-    <% unless @schedule.expected_weight.nil? or @schedule.max_weight.nil? or @schedule.mean_weight.nil? %>
-      <p><b>Expected Weight:</b> <%= @schedule.expected_weight %> <em>(current mean = <%= @schedule.mean_weight.round %>, max = <%= @schedule.max_weight.round %>)</em></p>
+    <% unless @chain.expected_weight.nil? or @chain.max_weight.nil? or @chain.mean_weight.nil? %>
+      <p><b>Expected Weight:</b> <%= @chain.expected_weight %> <em>(current mean = <%= @chain.mean_weight.round %>, max = <%= @chain.max_weight.round %>)</em></p>
     <% end %>
 
-    <% unless @schedule.hilliness.nil? %>
-      <p><b>Hilliness:</b> <%= ScheduleChain::HILLINESS_OPTIONS[@schedule.hilliness] %></p>
+    <% unless @chain.hilliness.nil? %>
+      <p><b>Hilliness:</b> <%= ScheduleChain::HILLINESS_OPTIONS[@chain.hilliness] %></p>
     <% end %>
 
-    <% unless @schedule.difficulty_rating.nil? %>
-      <p><b>Overall Difficulty:</b> <%= ScheduleChain::DIFFICULTY_OPTIONS[@schedule.difficulty_rating] %></p>
+    <% unless @chain.difficulty_rating.nil? %>
+      <p><b>Overall Difficulty:</b> <%= ScheduleChain::DIFFICULTY_OPTIONS[@chain.difficulty_rating] %></p>
     <% end %>
 
     <h3>
@@ -59,16 +59,16 @@
       Current Volunteers
     </h3>
     <p>
-      <% if @schedule.volunteers.count == 0 %>
+      <% if @chain.volunteers.count == 0 %>
         No volunteers yet...
-        <%=link_to take_schedule_chains_path(id: @schedule), confirm: "Are you sure you want to sign up for this weekly pickup?", class: 'btn btn-primary' do %>
+        <%=link_to take_schedule_chains_path(id: @chain), confirm: "Are you sure you want to sign up for this weekly pickup?", class: 'btn btn-primary' do %>
           <i class="fa fa-hand-rock-o"></i>
           <strong>Signup for this <u>weekly</u> pickup now!</strong>
         <% end %>
 
       <% else %>
         <ul>
-          <% @schedule.volunteers.each do |volunteer| %>
+          <% @chain.volunteers.each do |volunteer| %>
             <li><%= link_to volunteer.name, "mailto:#{volunteer.email}" %><%= volunteer.phone.nil? ? "" : ": #{volunteer.phone}" %></li>
           <% end %>
         </ul>
@@ -107,7 +107,7 @@
 
   <div class="col-sm-6">
 
-    <% if @schedule.mappable? %>
+    <% if @chain.mappable? %>
       <h2>
         <i class='fa fa-bicycle'></i>
         Bicycling Directions
@@ -128,10 +128,10 @@
 
 <div class="row">
   <div class="col-sm-12">
-    <% if @schedule.functional? %>
+    <% if @chain.functional? %>
       <h3>Stops:</h3>
       <p>
-  	  <% @schedule.schedules.each do |stop|
+  	  <% @chain.schedules.each do |stop|
         next if stop.nil? or stop.location.nil? %>
 
         <div class="col-sm-6">

--- a/spec/interactors/create_schedule_chain_spec.rb
+++ b/spec/interactors/create_schedule_chain_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreateScheduleChain do
+  describe '::call' do
+    subject do
+      described_class.call(
+        schedule_chain: chain
+      )
+    end
+
+    let(:chain) do
+      build(:schedule_chain, :one_time)
+    end
+
+    it 'saves the schedule' do
+      expect(subject.success?).to eq(true)
+      expect(chain).to be_persisted
+    end
+
+    it 'does not create rescue logs' do
+      expect {
+        subject
+      }.to_not(change { Log.count })
+    end
+
+    it 'fails if it cannot save the schedule' do
+      expect(chain).to receive(:save).and_return false
+      expect(subject.success?).to eq(false)
+    end
+
+    context 'schedule is one time and same day' do
+      let!(:donor) { create(:donation_schedule, schedule_chain: chain, location: create(:hub), position: 1) }
+      let!(:recipient) { create(:recipient_schedule, schedule_chain: chain, location: create(:hub), position: 2) }
+
+      let(:chain) do
+        create(:schedule_chain, :one_time, detailed_date: Date.today)
+      end
+
+      it 'creates rescue logs' do
+        expect {
+          subject
+        }.to change { Log.count }.by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Overview
Resolves #163 by reusing some LogGenerator services to create rescue logs for one-time, same day schedules when they are created.

## Notes
Normally, a daily task (foodrobot:generate_logs) would generate all the logs from the schedule, but often this would happen too late for schedules created on the same day.
