### PR TITLE
Monkey Patch Postgres to fix Panic string issue.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 ruby File.read('.ruby-version').strip
 
 # the base rails libraries
-gem 'pg'
+gem 'pg', '~> 0.18.4'
 gem 'rails', '~> 3.2.16'
 gem 'rails_12factor'
 gem 'thin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -432,7 +432,7 @@ DEPENDENCIES
   json
   newrelic_rpm
   paperclip!
-  pg
+  pg (~> 0.18.4)
   poltergeist (~> 1.12)
   prawn (~> 2.1.0)
   prawn-table (~> 0.2.2)

--- a/config/initializers/postgresql_adapter_monkeypatch.rb
+++ b/config/initializers/postgresql_adapter_monkeypatch.rb
@@ -1,0 +1,10 @@
+require 'active_record/connection_adapters/postgresql_adapter'
+
+class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+  def set_standard_conforming_strings
+    old, self.client_min_messages = client_min_messages, 'warning'
+    execute('SET standard_conforming_strings = on', 'SCHEMA') rescue nil
+  ensure
+    self.client_min_messages = old
+  end
+end


### PR DESCRIPTION
## Overview

Heroku upgraded our Postgres version today via regular maintenance (12-10-2020) and it brought down with a message `PG::InvalidParameterValue: ERROR: invalid value for parameter “client_min_messages”: “panic”` 

Found a way to monkey patch and get the app back up via: 
https://stackoverflow.com/questions/58763542/pginvalidparametervalue-error-invalid-value-for-parameter-client-min-messag

I think a better option would to re-provision to postgres 9.6 specifically. I couldn't check the version this AM, but best guess is that we are on 10 or 11 version that dropped the support for 'panic'. I don't have a ton of knowledge about this as of now